### PR TITLE
Add NAMD package

### DIFF
--- a/apps/namd/3/build.sh
+++ b/apps/namd/3/build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+        
+# Set safety options
+set -eu
+
+# Clone Spack version
+git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+
+# Souce environment
+. spack/share/spack/setup-env.sh
+
+# Clone Buildit configuration
+#git clone https://github.com/i/buildit.git
+# Use local copy
+ln -s ../../../ ./buildit
+
+# Disable local config
+export SPACK_DISABLE_LOCAL_CONFIG=true
+
+# Create local directory "myenv" for Spack environment
+spack env create -d myenv
+
+# Activate environment
+spack env activate ./myenv
+
+# Initialise environment
+spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
+spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add view:true
+spack config add concretizer:unify:true
+spack config add concretizer:reuse:false
+
+# Add local repo to environment
+spack repo add ./buildit/repo/v0.23/isamrepo
+
+# Add application
+spack add namd@3.0
+
+# Check dependencies
+spack concretize
+
+# Install application
+spack install
+
+# Unload and reload environment (to load new view)
+spack env deactivate && spack env activate ./myenv
+
+# Check application is found
+which namd3
+
+# Deactivate environment
+spack env deactivate
+

--- a/config/3/v0.23/packages.yaml
+++ b/config/3/v0.23/packages.yaml
@@ -8,6 +8,9 @@ packages:
       pkgconfig: [pkg-config]
     permissions:
       write: group
+  namd:
+    require:
+    - "^charmpp@8.0.0 backend=ofi pmi=cray-pmi"
   numactl:
     require:
     - "%gcc"

--- a/repo/v0.23/isamrepo/packages/charmpp/ofi-crayshasta-arm.patch
+++ b/repo/v0.23/isamrepo/packages/charmpp/ofi-crayshasta-arm.patch
@@ -1,9 +1,9 @@
-diff --git a/src/arch/ofi-crayshasta/conv-mach-cxi.h b/src/arch/ofi-crayshasta/conv-mach-cxi.h
-index 8267a8fdb..a91512676 100644
---- a/src/arch/ofi-crayshasta/conv-mach-cxi.h
-+++ b/src/arch/ofi-crayshasta/conv-mach-cxi.h
-@@ -79,7 +79,7 @@
- #define CMK_LBDB_ON                                       1
+diff --git a/src/arch/ofi-crayshasta/conv-mach.h b/src/arch/ofi-crayshasta/conv-mach.h
+index 61d295df3..9e15fd2a9 100644
+--- a/src/arch/ofi-crayshasta/conv-mach.h
++++ b/src/arch/ofi-crayshasta/conv-mach.h
+@@ -74,7 +74,7 @@
+ #define CMK_LBDB_ON					   1
  
  #define CMK_64BIT                      1
 -#define CMK_AMD64                      1
@@ -11,35 +11,3 @@ index 8267a8fdb..a91512676 100644
  
  /* Other possible definitions:
  
-diff --git a/src/arch/ofi-crayshasta/conv-mach-cxi.sh b/src/arch/ofi-crayshasta/conv-mach-cxi.sh
-index 3e6a6b5db..36171d579 100644
---- a/src/arch/ofi-crayshasta/conv-mach-cxi.sh
-+++ b/src/arch/ofi-crayshasta/conv-mach-cxi.sh
-@@ -11,11 +11,11 @@
- 
- if test -z "$USER_OPTS_LD"
- then
--    module load cray-libpals cray-pmi libfabric
-+    module load cray-pmi libfabric
-     CMK_LIBFABRIC_INC=`pkg-config --cflags libfabric`
-     CMK_LIBFABRIC_LIBS=`pkg-config --libs libfabric`
--    CMK_LIBPALS_LIBS=`pkg-config --libs libpals`
--    CMK_LIBPALS_LDPATH=`pkg-config libpals --variable=libdir`
-+    CMK_LIBPALS_LIBS=""
-+    CMK_LIBPALS_LDPATH=""
-     CMK_PMI_INC=`pkg-config --cflags cray-pmi`
-     CMK_PMI_LIBS=`pkg-config --libs cray-pmi`
-     CMK_LIBPMI_LDPATH=`pkg-config cray-pmi --variable=libdir`
-diff --git a/src/arch/ofi-crayshasta/conv-mach.h b/src/arch/ofi-crayshasta/conv-mach.h
-index bef80a949..b66673fe1 100644
---- a/src/arch/ofi-crayshasta/conv-mach.h
-+++ b/src/arch/ofi-crayshasta/conv-mach.h
-@@ -74,7 +74,7 @@
- #define CMK_LBDB_ON                                       1
- 
- #define CMK_64BIT                      1
--#define CMK_AMD64                      1
-+#define CMK_ARM                        1
- #ifdef CMK_HAS_GET_MYADDRESS
- #undef CMK_HAS_GET_MYADDRESS
- #define CMK_HAS_GET_MYADDRESS 0

--- a/repo/v0.23/isamrepo/packages/charmpp/ofi-linux-arm8.patch
+++ b/repo/v0.23/isamrepo/packages/charmpp/ofi-linux-arm8.patch
@@ -1,0 +1,294 @@
+diff --git a/src/arch/common/conv-mach-craype.sh b/src/arch/common/conv-mach-craype.sh
+index b30eba6560..01055d4562 100644
+--- a/src/arch/common/conv-mach-craype.sh
++++ b/src/arch/common/conv-mach-craype.sh
+@@ -1,3 +1,6 @@
++CMK_BUILD_CRAY=1
++
++CMK_CRAY_NOGNI=1
+ 
+ PGCC=`CC -V 2>&1 | grep pgCC`
+ ICPC=`CC -V 2>&1 | grep Intel`
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-cxi.h b/src/arch/ofi-linux-arm8/conv-mach-cxi.h
+new file mode 100644
+index 0000000000..8267a8fdb8
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-cxi.h
+@@ -0,0 +1,94 @@
++#ifndef _CONV_MACH_H
++#define _CONV_MACH_H
++
++#define CMK_OFI                                            1
++/* for Slingshot-11 the provider is CXI, this is notably different
++ in how memory registration is handled from the old OFI. */
++#ifdef CMK_CXI
++#undef CMK_CXI
++#endif
++#define CMK_CXI                                        1
++
++/* define the default linker, together with its options */
++#define CMK_DLL_CC   "g++ -shared -O3 -o "
++
++/* 1 if the machine has a function called "getpagesize()", 0 otherwise .
++   used in the memory files of converse */
++#define CMK_GETPAGESIZE_AVAILABLE                          1
++
++/* defines which version of memory handlers should be used.
++   used in conv-core/machine.C */
++#define CMK_MALLOC_USE_GNU_MALLOC                          0
++#define CMK_MALLOC_USE_OS_BUILTIN                          1
++
++#define CMK_MEMORY_PAGESIZE                                4096
++#define CMK_MEMORY_PROTECTABLE                             1
++
++/* the following definitions set the type of shared variables to be used. only
++   one of them must be 1, all the others 0. The different implementations are in
++   converse.h. Typically used are UNAVAILABLE for non SMP versions and
++   POSIX_THREADS_SMP for SMP versions. The others are used only in special
++   cases: NT_THREADS for Windows. */
++#define CMK_SHARED_VARS_UNAVAILABLE                        1 /* non SMP versions */
++#define CMK_SHARED_VARS_POSIX_THREADS_SMP                  0 /* SMP versions */
++#define CMK_SHARED_VARS_NT_THREADS                         0
++
++/* the following define if signal handlers should be used, both equal to zero
++   means that signals will not be used. only one of the following can be 1, the
++   other must be 0. they differ in the fact that the second (_WITH_RESTART)
++   enables retry on interrupt (a function is recalled upon interrupt and does
++   not return EINTR as in the first case) */
++#define CMK_SIGNAL_USE_SIGACTION                           0
++#define CMK_SIGNAL_USE_SIGACTION_WITH_RESTART              1
++
++/* specifies whether the CthCpv variables should be defined as Cpv (0) or
++   directly as normal c variables (1) */
++#define CMK_THREADS_REQUIRE_NO_CPV                         0
++
++/* decide which is the default implementation of the threads (see threads.C)
++   Only one of the following can be 1. If none of them is selected, qthreads
++   will be used as default. This default can be overwritten at compile time
++   using -DCMK_THREADS_BUILD_"type"=1 */
++#define CMK_THREADS_USE_CONTEXT                            0
++#define CMK_THREADS_USE_FCONTEXT                           1
++#define CMK_THREADS_USE_JCONTEXT                           0
++#define CMK_THREADS_USE_PTHREADS                           0
++
++/* Specifies what kind of timer to use, and the correspondent headers will be
++   included in convcore.C. If none is selected, then the machine.C file needs to
++   implement the timer primitives. */
++#define CMK_TIMER_USE_RTC                                  0
++#define CMK_TIMER_USE_RDTSC                                0
++#define CMK_TIMER_USE_GETRUSAGE                            1
++#define CMK_TIMER_USE_SPECIAL                              0
++#define CMK_TIMER_USE_TIMES                                0
++
++/* Specifies what the processor will do when it is idle, either sleep (1) or go
++   into busy waiting mode (0). In convcore.C there are a few files included if
++   sleeping mode, but the real distinct implementation is in the machine.C
++   file. */
++#define CMK_WHEN_PROCESSOR_IDLE_USLEEP                     0
++
++/* specifies whether there is a web server collecting utilization statistics (1)
++   or not (0) */
++#define CMK_WEB_MODE                                       1
++
++#define CMK_DEBUG_MODE                                     0
++
++/* enables the load balancer framework. set to 1 for almost all the machines */
++#define CMK_LBDB_ON					   1
++
++#define CMK_64BIT                      1
++#define CMK_AMD64                      1
++
++/* Other possible definitions:
++
++In fault tolerant architectures, CK_MEM_CHECKPOINT can be set. In this case the
++extended header must contain also another field called "pn" (phase number).
++
++*/
++
++/* Use PMI2 by default on Cray systems with cray-pmi */
++#include "conv-mach-slurmpmi2cray.h"
++
++#endif
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-cxi.sh b/src/arch/ofi-linux-arm8/conv-mach-cxi.sh
+new file mode 100644
+index 0000000000..df5c695ba6
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-cxi.sh
+@@ -0,0 +1,27 @@
++
++
++# For libfabric If the user doesn't pass --basedir, use pkg-config for
++#libfabric headers and library to avoid some linker wackiness, we
++#order them: pal libs, PMI libs, lib64.  So that if someplace (i.e.,
++#NCSA) puts regular pmi libs in /usr/lib64, we get them from the
++#package's cray-pmi dir not their unextended pmi.  libpals comes along
++#for the ride here due to a dependency in pmi.  fabric can just go
++#after the others.
++
++
++if test -z "$USER_OPTS_LD"
++then
++    module load cray-pmi libfabric
++    CMK_LIBFABRIC_INC=`pkg-config --cflags libfabric`
++    CMK_LIBFABRIC_LIBS=`pkg-config --libs libfabric`
++    CMK_LIBPALS_LIBS=""
++    CMK_LIBPALS_LDPAT=""
++    CMK_PMI_INC=`pkg-config --cflags cray-pmi`
++    CMK_PMI_LIBS=`pkg-config --libs cray-pmi`
++    CMK_LIBPMI_LDPATH=`pkg-config cray-pmi --variable=libdir`
++    CMK_INCDIR="$CMK_PMI_INC -I/usr/include/slurm/ $CMK_LIBFABRIC_INC $CMK_INCDIR "
++    CMK_LIBS="-Wl,-rpath,$CMK_LIBPALS_LDPATH,-rpath,$CMK_LIBPMI_LDPATH $CMK_LIBPALS_LIBS $CMK_PMI_LIBS -L/usr/lib64/ $CMK_LIBFABRIC_LIBS $CMK_LIBS "
++fi
++
++# For runtime
++CMK_INCDIR="$CMK_INCDIR -I./proc_management/"
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-pthreads.h b/src/arch/ofi-linux-arm8/conv-mach-pthreads.h
+new file mode 100644
+index 0000000000..94e01fd177
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-pthreads.h
+@@ -0,0 +1,10 @@
++
++#undef CMK_MALLOC_USE_GNU_MALLOC
++#undef CMK_MALLOC_USE_OS_BUILTIN
++#undef CMK_MALLOC_USE_GNUOLD_MALLOC
++#define CMK_MALLOC_USE_OS_BUILTIN                          1
++                                                                                
++#undef CMK_THREADS_USE_CONTEXT
++#undef CMK_THREADS_USE_PTHREADS
++#define CMK_THREADS_USE_PTHREADS                           1
++
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-pthreads.sh b/src/arch/ofi-linux-arm8/conv-mach-pthreads.sh
+new file mode 100644
+index 0000000000..34cb4c68cf
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-pthreads.sh
+@@ -0,0 +1,2 @@
++
++CMK_LIBS="$CMK_LIBS -lpthread "
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-smp.h b/src/arch/ofi-linux-arm8/conv-mach-smp.h
+new file mode 100644
+index 0000000000..5e89297ba1
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-smp.h
+@@ -0,0 +1,20 @@
++
++#define CMK_SMP						   1
++
++
++#undef CMK_SHARED_VARS_UNAVAILABLE
++#undef CMK_SHARED_VARS_POSIX_THREADS_SMP
++#define CMK_SHARED_VARS_UNAVAILABLE                        0
++#define CMK_SHARED_VARS_POSIX_THREADS_SMP                  1
++
++#undef CMK_MALLOC_USE_GNU_MALLOC
++#undef CMK_MALLOC_USE_OS_BUILTIN
++#define CMK_MALLOC_USE_GNU_MALLOC                          0
++#define CMK_MALLOC_USE_OS_BUILTIN                          1
++
++/*#define CMK_MMAP_PROBE                                     1 */
++
++/*#define CMK_PCQUEUE_LOCK				   1 */
++/*#define CMK_USE_MFENCE 					   1 */
++/* Replaced by CMK_NOT_USE_TLS_THREAD as default */
++/*#define CMK_USE_TLS_THREAD                                 1*/
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-smp.sh b/src/arch/ofi-linux-arm8/conv-mach-smp.sh
+new file mode 100644
+index 0000000000..ce625d65e9
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-smp.sh
+@@ -0,0 +1,3 @@
++CMK_DEFS="$CMK_DEFS -D_REENTRANT"
++CMK_LIBS="-lpthread $CMK_LIBS "
++CMK_SMP='1'
+diff --git a/src/arch/ofi-linux-arm8/conv-mach.h b/src/arch/ofi-linux-arm8/conv-mach.h
+new file mode 100644
+index 0000000000..ec4b7bb384
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach.h
+@@ -0,0 +1,63 @@
++
++#ifndef _CONV_MACH_H
++#define _CONV_MACH_H
++
++#define CMK_NETPOLL         1
++
++#define CMK_ARM					  1 
++#define CMK_OFI 1
++#define CMK_ASYNC_NOT_NEEDED                               0
++#define CMK_ASYNC_USE_FIOASYNC_AND_FIOSETOWN               0
++#define CMK_ASYNC_USE_FIOASYNC_AND_SIOCSPGRP               0
++#define CMK_ASYNC_USE_FIOSSAIOSTAT_AND_FIOSSAIOOWN         0
++#define CMK_ASYNC_USE_F_SETFL_AND_F_SETOWN                 1
++
++#define CMK_DLL_CC  "g++ -shared -O3 -o "
++
++#define CMK_GETPAGESIZE_AVAILABLE                          1
++
++#define CMK_MALLOC_USE_GNU_MALLOC                          0
++#define CMK_MALLOC_USE_OS_BUILTIN                          1
++
++#define CMK_MEMORY_PAGESIZE                                4096
++#define CMK_MEMORY_PROTECTABLE                             0
++
++
++#define CMK_SSH_IS_A_COMMAND                               1
++#define CMK_SSH_NOT_NEEDED                                 0
++
++#define CMK_SHARED_VARS_UNAVAILABLE                        1
++
++#define CMK_THREADS_USE_CONTEXT                            1
++#define CMK_THREADS_USE_JCONTEXT                           0
++#define CMK_THREADS_USE_FCONTEXT                           0
++#define CMK_THREADS_USE_PTHREADS                           0
++#define CMK_THREADS_ARE_WIN32_FIBERS                       0
++
++#define CMK_SIGNAL_NOT_NEEDED                              0
++#define CMK_SIGNAL_USE_SIGACTION                           0
++#define CMK_SIGNAL_USE_SIGACTION_WITH_RESTART              1
++
++#define CMK_THREADS_REQUIRE_NO_CPV                         0
++#define CMK_THREADS_COPY_STACK                             0
++
++#define CMK_TIMER_USE_RDTSC                                0
++#define CMK_TIMER_USE_GETRUSAGE                            1
++#define CMK_TIMER_USE_SPECIAL                              0
++#define CMK_TIMER_USE_TIMES                                0
++
++#define CMK_64BIT   1 
++#define CMK_32BIT   0
++#define CMK_WHEN_PROCESSOR_IDLE_BUSYWAIT                   0
++#define CMK_WHEN_PROCESSOR_IDLE_USLEEP                     1
++
++
++#define CMK_DEBUG_MODE					   0 
++#define CMK_WEB_MODE                                       1
++
++#define CMK_LBDB_ON					   1
++
++
++#endif
++
++
+diff --git a/src/arch/ofi-linux-arm8/conv-mach.sh b/src/arch/ofi-linux-arm8/conv-mach.sh
+new file mode 100644
+index 0000000000..eb3bcc4358
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach.sh
+@@ -0,0 +1,16 @@
++. $CHARMINC/cc-gcc.sh
++
++# For libfabric
++#If the user doesn't pass --basedir, use defaults for libfabric headers and library
++if test -z "$USER_OPTS_LD"
++then
++    CMK_INCDIR="-I/usr/include/"
++#    CMK_LIBDIR="-L/usr/lib64/"
++fi
++
++CMK_LIBS="$CMK_LIBS -lfabric"
++
++# For runtime
++CMK_INCDIR="$CMK_INCDIR -I./proc_management/ -I./proc_management/simple_pmi/"
++
++CMK_QT='generic64-light'


### PR DESCRIPTION
NAMD is quite complicated due to the binary packages limited in configuration and the source build configuration requiring charm++.  This sets required configuration and updates NAMD to work on Isambard 3.

Link to project: https://www.ks.uiuc.edu/Research/namd/
