### PR TITLE
Add Chapel package

### DIFF
--- a/apps/chapel/3/build.sh
+++ b/apps/chapel/3/build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+        
+# Set safety options
+set -eu
+
+# Clone Spack version
+git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+
+# Souce environment
+. spack/share/spack/setup-env.sh
+
+# Clone Buildit configuration
+#git clone https://github.com/i/buildit.git
+# Use local copy
+ln -s ../../../ ./buildit
+
+# Disable local config
+export SPACK_DISABLE_LOCAL_CONFIG=true
+
+# Create local directory "myenv" for Spack environment
+spack env create -d myenv
+
+# Activate environment
+spack env activate ./myenv
+
+# Initialise environment
+spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
+spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add view:true
+spack config add concretizer:unify:true
+spack config add concretizer:reuse:false
+
+# Add local repo to environment
+spack repo add ./buildit/repo/v0.23/isamrepo
+
+# Add application
+spack add chapel
+
+# Check dependencies
+spack concretize
+
+# Install application
+spack install
+
+# Unload and reload environment (to load new view)
+spack env deactivate && spack env activate ./myenv
+
+# Check application is found
+which chpl
+
+# Deactivate environment
+spack env deactivate
+

--- a/config/3/v0.23/packages.yaml
+++ b/config/3/v0.23/packages.yaml
@@ -8,6 +8,10 @@ packages:
       pkgconfig: [pkg-config]
     permissions:
       write: group
+  chapel:
+    variants: comm=ofi host_platform=linux64 launcher=slurm-srun libfabric=spack
+    require:
+    - "%gcc"
   namd:
     require:
     - "^charmpp@8.0.0 backend=ofi pmi=cray-pmi"
@@ -75,7 +79,7 @@ packages:
     buildable: false
     version: [1.22.0]
     externals:
-    - spec: libfabric@1.22.0
+    - spec: libfabric@1.22.0 fabrics=cxi
       prefix: /opt/cray/libfabric/1.22.0
       modules: [libfabric/1.22.0]
   cray-pmi:


### PR DESCRIPTION
Chapel has been requested from a user.  Some complications exist.  

At Chapel 2.2 it requires all development libraries to build static executables which was highlighted when libfabric uses libjson-c and Chapel complained.  At 2.3 a dynamic linking is possible and would not require these libraries on the login node. 

Link: https://chapel-lang.org