### PR TITLE
Update et package

### DIFF
--- a/apps/et/3/build.sh
+++ b/apps/et/3/build.sh
@@ -24,8 +24,8 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/macs3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/macs3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
+spack config add -f buildit/config/3/v0.23/packages.yaml
 spack config add view:true
 spack config add concretizer:unify:true
 spack config add concretizer:reuse:false

--- a/config/3/v0.23/packages.yaml
+++ b/config/3/v0.23/packages.yaml
@@ -2,7 +2,7 @@ packages:
   all:
     compiler: [gcc@12.3, gcc@13.2, nvhpc@24.5, cce@18.0.0]
     providers:
-      blas: [cray-libsci, blis]
+      blas: [cray-libsci, blis, openblas]
       lapack: [cray-libsci, openblas]
       mpi: [cray-mpich, openmpi]
       pkgconfig: [pkg-config]
@@ -12,6 +12,9 @@ packages:
     variants: comm=ofi host_platform=linux64 launcher=slurm-srun libfabric=spack
     require:
     - "%gcc"
+  et:
+    require:
+    - "^openblas +ilp64 ^libint tune=et"
   namd:
     require:
     - "^charmpp@8.0.0 backend=ofi pmi=cray-pmi"

--- a/config/macs3/v0.23/packages.yaml
+++ b/config/macs3/v0.23/packages.yaml
@@ -2,12 +2,15 @@ packages:
   all:
     compiler: [gcc@12.3, gcc@13.2, nvhpc@24.5, cce@17.0.1]
     providers:
-      blas: [cray-libsci]
-      lapack: [cray-libsci]
+      blas: [cray-libsci, blis, openblas]
+      lapack: [cray-libsci, openblas]
       mpi: [cray-mpich, openmpi]
       pkgconfig: [pkg-config]
     permissions:
       write: group
+  et:
+    require:
+    - "^openblas +ilp64 ^libint tune=et"
   openmpi:
     variants: fabrics=ofi
   cray-libsci:

--- a/repo/v0.23/isamrepo/packages/et/package.py
+++ b/repo/v0.23/isamrepo/packages/et/package.py
@@ -53,7 +53,7 @@ class Et(CMakePackage):
 
     def cmake_args(self):
         args = []
-        craysci = self.spec['blas'].libs + self.spec['lapack'].libs
+        mathlibs = self.spec['blas'].libs + self.spec['lapack'].libs
         args.extend(
             [
                 f"-DENABLE_64BIT_INTEGERS=ON",
@@ -70,7 +70,7 @@ class Et(CMakePackage):
                 f"-DLIBINT2_ROOT=" + self.spec["libint"].prefix,
                 f"-DENABLE_AUTO_BLAS=OFF",
                 f"-DENABLE_AUTO_LAPACK=OFF",
-                f"-DEXTRA_LINKER_FLAGS={craysci.ld_flags}",
+                f"-DEXTRA_LINKER_FLAGS={mathlibs.ld_flags}",
             ]
         )
 


### PR DESCRIPTION
Et package at the moment is hardwired to 64bit array sizes.  cray-libsci may not support them so let's specify openblas to provide the lapack/blas.

Also tidied up defining requirements for et in packages.yaml.