### PR TITLE
Add threading to openblas for et

### DIFF
--- a/config/3/v0.23/packages.yaml
+++ b/config/3/v0.23/packages.yaml
@@ -18,7 +18,7 @@ packages:
     - "%gcc"
   et:
     require:
-    - "^openblas +ilp64 ^libint tune=et"
+    - "^openblas +ilp64 threads=openmp ^libint tune=et"
   gmp:
     require:
     - "%gcc"

--- a/config/macs3/v0.23/packages.yaml
+++ b/config/macs3/v0.23/packages.yaml
@@ -13,7 +13,7 @@ packages:
     - "^openblas ^fftw"
   et:
     require:
-    - "^openblas +ilp64 ^libint tune=et"
+    - "^openblas +ilp64 threads=openmp ^libint tune=et"
   namd:
     require:
     - "^charmpp@8.0.0 backend=ofi pmi=cray-pmi"


### PR DESCRIPTION
et requires multithreading using OpenMP in openblas to get parallel performance.