### PR TITLE
Add Slurm support to OpenMPI.

### DIFF
--- a/config/3/v0.23/packages.yaml
+++ b/config/3/v0.23/packages.yaml
@@ -46,7 +46,7 @@ packages:
     require:
     - "%gcc"
   openmpi:
-    variants: fabrics=ofi
+    variants: fabrics=ofi schedulers=slurm
   armpl-gcc:
     buildable: false
     version: ["24.10"]
@@ -226,6 +226,10 @@ packages:
     externals:
     - prefix: /usr
       spec: sed@4.4
+  slurm:
+    externals:
+    - prefix: /usr
+      spec: slurm@23.02.7
   subversion:
     externals:
     - prefix: /usr


### PR DESCRIPTION
OpenMPI can use Slurm (doesn't seem to require slurm-devel) so lets add it as a dependency for consistency.