### PR TITLE
Update Chapel including environment variables.

### DIFF
--- a/apps/chapel/3/build.sh
+++ b/apps/chapel/3/build.sh
@@ -26,6 +26,7 @@ spack env activate ./myenv
 # Initialise environment
 spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
 spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
 spack config add concretizer:reuse:false

--- a/config/3/v0.23/packages.yaml
+++ b/config/3/v0.23/packages.yaml
@@ -13,7 +13,7 @@ packages:
     prefer:
     - "^openblas ^fftw"
   chapel:
-    variants: comm=ofi comm_ofi_oob=pmi2 host_platform=linux64 launcher=slurm-srun libfabric=spack
+    variants: comm=ofi comm_ofi_oob=pmi2 host_platform=linux64 launcher=slurm-srun libfabric=spack hwloc=spack
     require:
     - "%gcc"
   et:

--- a/repo/v0.23/isamrepo/packages/chapel/fix_checkChplInstall.patch
+++ b/repo/v0.23/isamrepo/packages/chapel/fix_checkChplInstall.patch
@@ -1,0 +1,35 @@
+commit ba58b4edc86dfcf0b2bdb9f3c910a2181a21060a
+Author: Jade Abraham <jade.abraham@hpe.com>
+Date:   Mon Nov 25 08:19:07 2024 -0800
+
+    fix make check for gpu
+    
+    Signed-off-by: Jade Abraham <jade.abraham@hpe.com>
+
+diff --git a/util/test/checkChplInstall b/util/test/checkChplInstall
+index e0e82a471e..5b1c638835 100755
+--- a/util/test/checkChplInstall
++++ b/util/test/checkChplInstall
+@@ -213,12 +213,18 @@ else
+ fi
+ 
+ # Find number of locales and .good file
++NUMLOCALES=1
++GOOD=${TEST_DIR}/${TEST_JOB}.good
+ if [ ${chpl_comm} == "none" ]; then
+-    NUMLOCALES=1
+-    GOOD=${TEST_DIR}/${TEST_JOB}.comm-none.good
++    # use comm-none specific good file if it exists
++    if [ -f ${TEST_DIR}/${TEST_JOB}.comm-none.good ]; then
++        GOOD=${TEST_DIR}/${TEST_JOB}.comm-none.good
++    fi
+ else
+-    NUMLOCALES="$(cat ${TEST_DIR}/NUMLOCALES)"
+-    GOOD=${TEST_DIR}/${TEST_JOB}.good
++    # use specific NUMLOCALES if it exists
++    if [ -f ${TEST_DIR}/NUMLOCALES ]; then
++      NUMLOCALES="$(cat ${TEST_DIR}/NUMLOCALES)"
++    fi
+ fi
+ 
+ # Check for valid launchers

--- a/repo/v0.23/isamrepo/packages/chapel/fix_chpl_line_length.patch
+++ b/repo/v0.23/isamrepo/packages/chapel/fix_chpl_line_length.patch
@@ -1,0 +1,13 @@
+diff --git a/compiler/util/files.cpp b/compiler/util/files.cpp
+index 4183614988..9746baf935 100644
+--- a/compiler/util/files.cpp
++++ b/compiler/util/files.cpp
+@@ -211,7 +211,7 @@ void restoreDriverTmp(const char* tmpFilePath,
+
+   fileinfo* tmpFile = openTmpFile(tmpFilePath, "r");
+
+-  char strBuf[4096];
++  char strBuf[8192];
+   while (fgets(strBuf, sizeof(strBuf), tmpFile->fptr)) {
+     // Note: Using strlen here (instead of strnlen) is safe because fgets
+     // guarantees null termination.

--- a/repo/v0.23/isamrepo/packages/chapel/fix_chpl_shared_lib_path.patch
+++ b/repo/v0.23/isamrepo/packages/chapel/fix_chpl_shared_lib_path.patch
@@ -1,0 +1,102 @@
+diff --git a/util/chplenv/chpl_home_utils.py b/util/chplenv/chpl_home_utils.py
+index 5d85153835..b08fc2fc93 100644
+--- a/util/chplenv/chpl_home_utils.py
++++ b/util/chplenv/chpl_home_utils.py
+@@ -54,6 +54,45 @@ install_path_regex = re.compile(
+                                                   os.path.sep,
+                                                   os.path.sep))
+
++@memoize
++def get_chpl_configured_install_lib_prefix():
++    # gets the path to the lib directory for a prefix install, or None if not
++    # a prefix install
++    chpl_home = str(os.getenv("CHPL_HOME"))
++    if os.path.exists(os.path.join(chpl_home, "configured-prefix")):
++        with open(os.path.join(chpl_home, "CMakeLists.txt"), "r") as f:
++            # read CMakeLists.txt to get the CHPL_MAJOR_VERSION and
++            # CHPL_MINOR_VERSION and then construct the path from that
++            chpl_major_version = None
++            chpl_minor_version = None
++            for line in f:
++                if "set(CHPL_MAJOR_VERSION" in line:
++                    chpl_major_version = line.split()[1].strip(")")
++                if "set(CHPL_MINOR_VERSION" in line:
++                    chpl_minor_version = line.split()[1].strip(")")
++                if (
++                    chpl_major_version is not None
++                    and chpl_minor_version is not None
++                ):
++                    break
++        assert chpl_major_version is not None and chpl_minor_version is not None
++        chpl_version_string = "{}.{}".format(
++            chpl_major_version,
++            chpl_minor_version,
++        )
++        chpl_prefix = None
++        with open(os.path.join(chpl_home, "configured-prefix"), "r") as f:
++            chpl_prefix = f.read().strip()
++        assert chpl_prefix != "" and chpl_prefix is not None
++        return os.path.join(
++            chpl_prefix,
++            "lib",
++            "chapel",
++            chpl_version_string,
++            "compiler",
++        )
++    return None
++
+ @memoize
+ def get_chpl_version_from_install():
+     if get_prefix_install_prefix():
+@@ -189,6 +228,8 @@ def _main():
+     )
+     parser.add_option('--using-module', action='store_const',
+                       dest='func', const=using_chapel_module)
++    parser.add_option('--configured-install-lib-prefix', action='store_const',
++                      dest='func', const=get_chpl_configured_install_lib_prefix)
+     (options, args) = parser.parse_args()
+
+     if options.func:
+
+diff --git a/tools/chapel-py/setup.py b/tools/chapel-py/setup.py
+index 0f3dd9fea0..9be2a48cff 100644
+--- a/tools/chapel-py/setup.py
++++ b/tools/chapel-py/setup.py
+@@ -47,6 +47,18 @@ host_cxx = str(chpl_variables.get("CHPL_HOST_CXX"))
+
+ host_bin_subdir = str(chpl_variables.get("CHPL_HOST_BIN_SUBDIR"))
+ chpl_lib_path = os.path.join(chpl_home, "lib", "compiler", host_bin_subdir)
++# For installations using --prefix, the build and final lib paths are going to
++#  differ. figure out the install location now and write it to the rpath
++chpl_home_utils = os.path.join(
++    chpl_home, "util", "chplenv", "chpl_home_utils.py"
++)
++chpl_install_lib_path = (
++    subprocess.check_output(
++        ["python", chpl_home_utils, "--configured-install-lib-prefix"],
++    )
++    .decode(sys.stdout.encoding)
++    .strip()
++)
+
+ CXXFLAGS = []
+ if have_llvm and have_llvm != "none":
+@@ -64,11 +76,16 @@ CXXFLAGS += ["-std=c++17", "-I{}/frontend/include".format(chpl_home)]
+ LDFLAGS = []
+ LDFLAGS += [
+     "-L{}".format(chpl_lib_path),
++    "-Wl,-rpath,{}".format(chpl_lib_path),
+     "-lChplFrontendShared",
+-    "-Wl,-rpath",
+-    chpl_lib_path,
+ ]
+
++if chpl_install_lib_path != "None":
++    LDFLAGS += [
++        "-L{}".format(chpl_install_lib_path),
++        "-Wl,-rpath,{}".format(chpl_install_lib_path),
++    ]
++
+ os.environ["CC"] = host_cc
+ os.environ["CXX"] = host_cxx
+ setup(

--- a/repo/v0.23/isamrepo/packages/chapel/fix_chpl_shared_lib_path_2.3.patch
+++ b/repo/v0.23/isamrepo/packages/chapel/fix_chpl_shared_lib_path_2.3.patch
@@ -1,0 +1,96 @@
+diff --git a/tools/chapel-py/setup.py b/tools/chapel-py/setup.py
+index 30c2708724..0cf576ab25 100644
+--- a/tools/chapel-py/setup.py
++++ b/tools/chapel-py/setup.py
+@@ -47,6 +47,18 @@ host_cxx = str(chpl_variables.get("CHPL_HOST_CXX"))
+
+ host_bin_subdir = str(chpl_variables.get("CHPL_HOST_BIN_SUBDIR"))
+ chpl_lib_path = os.path.join(chpl_home, "lib", "compiler", host_bin_subdir)
++# For installations using --prefix, the build and final lib paths are going to
++#  differ figure out the install location now and write it to the rpath
++chpl_home_utils = os.path.join(
++    chpl_home, "util", "chplenv", "chpl_home_utils.py"
++)
++chpl_install_lib_path = (
++    subprocess.check_output(
++        ["python", chpl_home_utils, "--configured-install-lib-prefix"],
++    )
++    .decode(sys.stdout.encoding)
++    .strip()
++)
+
+ CXXFLAGS = []
+ if have_llvm and have_llvm != "none":
+@@ -68,6 +80,12 @@ LDFLAGS += [
+     "-lChplFrontendShared",
+ ]
+
++if chpl_install_lib_path != "None":
++    LDFLAGS += [
++        "-L{}".format(chpl_install_lib_path),
++        "-Wl,-rpath,{}".format(chpl_install_lib_path),
++    ]
++
+ if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
+     if str(chpl_variables.get("CHPL_HOST_PLATFORM")) == "darwin":
+         sys.exit(
+diff --git a/util/chplenv/chpl_home_utils.py b/util/chplenv/chpl_home_utils.py
+index 5f09ffed15..4b93849acd 100644
+--- a/util/chplenv/chpl_home_utils.py
++++ b/util/chplenv/chpl_home_utils.py
+@@ -54,6 +54,46 @@ install_path_regex = re.compile(
+                                                   os.path.sep,
+                                                   os.path.sep))
+
++@memoize
++def get_chpl_configured_install_lib_prefix():
++    # gets the path to the lib directory for a prefix install, or None if not
++    # a prefix install
++    chpl_home = str(os.getenv("CHPL_HOME"))
++    if os.path.exists(os.path.join(chpl_home, "configured-prefix")):
++        with open(os.path.join(chpl_home, "CMakeLists.txt"), "r") as f:
++            # read CMakeLists.txt to get the CHPL_MAJOR_VERSION and
++            # CHPL_MINOR_VERSION and then construct the path from that
++            chpl_major_version = None
++            chpl_minor_version = None
++            for line in f:
++                if "set(CHPL_MAJOR_VERSION" in line:
++                    chpl_major_version = line.split()[1].strip(")")
++                if "set(CHPL_MINOR_VERSION" in line:
++                    chpl_minor_version = line.split()[1].strip(")")
++                if (
++                    chpl_major_version is not None
++                    and chpl_minor_version is not None
++                ):
++                    break
++        assert chpl_major_version is not None and chpl_minor_version is not None
++        chpl_version_string = "{}.{}".format(
++            chpl_major_version,
++            chpl_minor_version,
++        )
++        chpl_prefix = None
++        with open(os.path.join(chpl_home, "configured-prefix"), "r") as f:
++            chpl_prefix = f.read().strip()
++        # Problems with the configured-prefix file - maybe empty
++        assert chpl_prefix != "" and chpl_prefix is not None
++        return os.path.join(
++            chpl_prefix,
++            "lib",
++            "chapel",
++            chpl_version_string,
++            "compiler",
++        )
++    return None
++
+ @memoize
+ def get_chpl_version_from_install():
+     if get_prefix_install_prefix():
+@@ -189,6 +229,8 @@ def _main():
+     )
+     parser.add_option('--using-module', action='store_const',
+                       dest='func', const=using_chapel_module)
++    parser.add_option('--configured-install-lib-prefix', action='store_const',
++                      dest='func', const=get_chpl_configured_install_lib_prefix)
+     (options, args) = parser.parse_args()
+
+     if options.func:

--- a/repo/v0.23/isamrepo/packages/chapel/fix_llvm_include_path_2.3.patch
+++ b/repo/v0.23/isamrepo/packages/chapel/fix_llvm_include_path_2.3.patch
@@ -1,0 +1,61 @@
+commit 687e1c9c1f33d4479b40f49fb23d73424fbebce8
+Author: Jade Abraham <jade.abraham@hpe.com>
+Date:   Fri Dec 13 08:54:37 2024 -0800
+
+    specialize idirafter
+    
+    Signed-off-by: Jade Abraham <jade.abraham@hpe.com>
+
+diff --git a/util/chplenv/chpl_llvm.py b/util/chplenv/chpl_llvm.py
+index 673a9e97f2..b5e9b30796 100755
+--- a/util/chplenv/chpl_llvm.py
++++ b/util/chplenv/chpl_llvm.py
+@@ -1027,7 +1027,7 @@ def get_clang_prgenv_args():
+ # Filters out C++ compilation flags from llvm-config.
+ # The flags are passed as a list of strings.
+ # Returns a list of strings containing the kept flags.
+-def filter_llvm_config_flags(flags):
++def filter_llvm_config_flags(llvm_val, flags):
+     ret = [ ]
+ 
+     platform_val = chpl_platform.get('host')
+@@ -1047,11 +1047,19 @@ def filter_llvm_config_flags(flags):
+             flag == '-std=c++14'):
+             continue # filter out these flags
+ 
+-        # change -I flags to -idirafter flags
++        #
++        # include LLVM headers as system headers
+         # this avoids warnings inside of LLVM headers by treating LLVM headers
+-        # as system headers without perturbing the include search path
++        #
++        # when adding LLVM=system as system headers, we should not perturb the
++        # include search path, so use -isystem-after/-idirafter
++        #
++        # when adding LLVM=bundled, we should include the LLVM headers as system
++        # headers and prefer the bundled headers, so use -isystem
++        #
++        include_flag = '-idirafter' if llvm_val == 'system' else '-isystem'
+         if flag.startswith('-I'):
+-            ret.append('-idirafter' + flag[2:])
++            ret.append(include_flag + flag[2:])
+             continue
+ 
+         if flag.startswith('-W'):
+@@ -1118,14 +1126,14 @@ def get_host_compile_args():
+ 
+         # Note, the cxxflags should include the -I for the include dir
+         cxxflags = run_command([llvm_config, '--cxxflags'])
+-        system.extend(filter_llvm_config_flags(cxxflags.split()))
++        system.extend(filter_llvm_config_flags('system', cxxflags.split()))
+ 
+     elif llvm_support_val == 'bundled':
+         # don't try to run llvm-config if it's not built yet
+         if is_included_llvm_built(llvm_val):
+             # Note, the cxxflags should include the -I for the include dir
+             cxxflags = run_command([llvm_config, '--cxxflags'])
+-            bundled.extend(filter_llvm_config_flags(cxxflags.split()))
++            bundled.extend(filter_llvm_config_flags('bundled', cxxflags.split()))
+ 
+         # TODO: is this still needed?
+         bundled.append('-Wno-comment')

--- a/repo/v0.23/isamrepo/packages/chapel/package.py
+++ b/repo/v0.23/isamrepo/packages/chapel/package.py
@@ -1,11 +1,14 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 import subprocess
 
+import llnl.util.lang
+
+import spack.platforms
 import spack.platforms.cray
 from spack.package import *
 from spack.util.environment import is_system_path, set_env
@@ -36,7 +39,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     homepage = "https://chapel-lang.org/"
 
-    url = "https://github.com/chapel-lang/chapel/archive/refs/tags/2.2.0.tar.gz"
+    url = "https://github.com/chapel-lang/chapel/releases/download/2.3.0/chapel-2.3.0.tar.gz"
     git = "https://github.com/chapel-lang/chapel.git"
 
     test_requires_compiler = True
@@ -55,15 +58,25 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
-    version("2.2.0", sha256="9b0ce16ed0b1c777647c3aa852d8d8cacea2c3d8a952548a238f07c0f357a0f9")
-    version("2.1.0", sha256="8e164d9a9e705e6b816857e84833b0922ce0bde6a36a9f3a29734830aac168ef")
-    version("2.0.1", sha256="47e1f3789478ea870bd4ecdf52acbe469d171b89b663309325431f3da7c75008")
-    version("2.0.0", sha256="a8cab99fd034c7b7229be8d4626ec95cf02072646fb148c74b4f48c460c6059c")
+    version("2.4.0", sha256="a51a472488290df12d1657db2e7118ab519743094f33650f910d92b54c56f315")
+    version("2.3.0", sha256="0185970388aef1f1fae2a031edf060d5eac4eb6e6b1089e7e3b15a130edd8a31")
+    version("2.2.0", sha256="bb16952a87127028031fd2b56781bea01ab4de7c3466f7b6a378c4d8895754b6")
+    version("2.1.0", sha256="72593c037505dd76e8b5989358b7580a3fdb213051a406adb26a487d26c68c60")
+    version("2.0.1", sha256="19ebcd88d829712468cfef10c634c3e975acdf78dd1a57671d11657574636053")
+    version("2.0.0", sha256="b5387e9d37b214328f422961e2249f2687453c2702b2633b7d6a678e544b9a02")
+
+    sanity_check_is_dir = ["bin", join_path("lib", "chapel"), join_path("share", "chapel")]
+    sanity_check_is_file = [join_path("bin", "chpl")]
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     patch("fix_spack_cc_wrapper_in_cray_prgenv.patch", when="@2.0.0:")
+    patch("fix_chpl_shared_lib_path.patch", when="@2.1.1:2.2 +python-bindings")  # PR 26388
+    patch("fix_chpl_shared_lib_path_2.3.patch", when="@2.2.1:2.3 +python-bindings")  # PR 26388
+    patch("fix_chpl_line_length.patch", when="@:2.3.0")  # PRs 26357, 26381, 26491
+    patch("fix_checkChplInstall.patch", when="@:2.3.0")  # PR 26317
+    patch("fix_llvm_include_path_2.3.patch", when="@=2.3.0 llvm=bundled")  # PR 26402
 
     launcher_names = (
         "amudprun",
@@ -96,7 +109,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "intel": "intel",
         "llvm": "llvm",
         "oneapi": "intel",
-        "pgi": "pgi",
         "rocmcc": "clang",
         "unset": "unset",
     }
@@ -131,7 +143,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "curl": "curl",
         "hdf5": "hdf5+hl~mpi",
         "libevent": "libevent",
-        "protobuf": "py-protobuf",
+        "protobuf": "protobuf",
         "ssl": "openssl",
         "yaml": "libyaml@0.1",
         "zmq": "libzmq",
@@ -154,14 +166,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     )
 
     variant(
-        "comm_ofi_oob",
-        values=("sockets", "mpi", "pmi2"),
-        default="sockets",
-        description="Select out-of-band support",
-        multi=False,
-    )
-
-    variant(
         "atomics",
         values=("unset", "cstdlib", "intrinsics", "locks"),
         default="unset",
@@ -179,6 +183,14 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         default="none",
         description="Build Chapel with multi-locale support",
         values=("gasnet", "none", "ofi", "ugni"),
+    )
+
+    variant(
+        "comm_ofi_oob",
+        values=("sockets", "mpi", "pmi2"),
+        default="sockets",
+        description="Select out-of-band support",
+        multi=False,
     )
 
     variant(
@@ -333,6 +345,13 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     )
 
     variant(
+        "python-bindings",
+        description="Also build the Python bindings for Chapel frontend (requires LLVM)",
+        default=False,
+        when="@2.2:",
+    )
+
+    variant(
         "re2",
         description="Build with re2 support",
         default="bundled",
@@ -414,6 +433,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "CHPL_GPU",
         "CHPL_GPU_ARCH",
         "CHPL_GPU_MEM_STRATEGY",
+        "CHPL_HOME",
         "CHPL_HOST_ARCH",
         # "CHPL_HOST_CC",
         "CHPL_HOST_COMPILER",
@@ -463,8 +483,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("llvm-amdgpu@4:5.4", when="+rocm llvm=spack")
     requires("llvm=bundled", when="+rocm ^hip@6.0:6.2", msg="ROCm 6 support requires llvm=bundled")
 
-    depends_on("cray-pmi", when="comm_ofi_oob=pmi2")
-
     conflicts(
         "comm_substrate=unset",
         when="comm=gasnet",
@@ -504,6 +522,11 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     with when("llvm=none"):
         conflicts("+cuda", msg="Cuda support requires building with LLVM")
         conflicts("+rocm", msg="ROCm support requires building with LLVM")
+        conflicts(
+            "+python-bindings",
+            msg="Python bindings require building with LLVM, see "
+            "https://chapel-lang.org/docs/tools/chapel-py/chapel-py.html#installation",
+        )
 
     # Add dependencies
 
@@ -512,7 +535,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     # TODO: keep up to date with util/chplenv/chpl_llvm.py
     with when("llvm=spack ~rocm"):
         depends_on("llvm@11:17", when="@:2.0.1")
-        depends_on("llvm@11:18", when="@2.1.0:")
+        depends_on("llvm@11:18", when="@2.1:2.2")
+        depends_on("llvm@11:19", when="@2.3:")
 
     # Based on docs https://chapel-lang.org/docs/technotes/gpu.html#requirements
     depends_on("llvm@16:", when="llvm=spack +cuda ^cuda@12:")
@@ -545,8 +569,15 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("gasnet conduits=none", when="gasnet=spack")
     depends_on("gasnet@2024.5.0: conduits=none", when="@2.1.0: gasnet=spack")
 
+    with when("+python-bindings"):
+        extends("python")
+
     depends_on("python@3.7:")
     depends_on("cmake@3.16:")
+    depends_on("cmake@3.20:", when="llvm=bundled")
+    
+    # Force use of cray-pmi in this case.  Not ideal.
+    depends_on("cray-pmi", when="comm_ofi_oob=pmi2")
 
     # ensure we can map the spack compiler name to one of the ones we recognize
     requires(
@@ -564,7 +595,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "%intel",
         "%llvm",
         "%oneapi",
-        "%pgi",
         "%rocmcc",
         policy="one_of",
     )
@@ -575,9 +605,26 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             env.unset(var)
 
     def build(self, spec, prefix):
-        make()
-        if spec.variants["chpldoc"].value:
-            make("chpldoc")
+        with set_env(CHPL_MAKE_THIRD_PARTY=join_path(self.build_directory, "third-party")):
+            make()
+            with set_env(CHPL_HOME=self.build_directory):
+                if spec.satisfies("+chpldoc"):
+                    make("chpldoc")
+                if spec.satisfies("+python-bindings"):
+                    make("chapel-py-venv")
+                    python("-m", "ensurepip", "--default-pip")
+                    python("-m", "pip", "install", "tools/chapel-py")
+
+    def install(self, spec, prefix):
+        make("install")
+        # We install CMakeLists.txt so we can later lookup the version number
+        # if working from a non-versioned release/branch (such as main)
+        if not self.is_versioned_release():
+            install("CMakeLists.txt", join_path(prefix.share, "chapel"))
+        install_tree("doc", join_path(prefix.share, "chapel", self._output_version_short, "doc"))
+        install_tree(
+            "examples", join_path(prefix.share, "chapel", self._output_version_short, "examples")
+        )
 
     def setup_chpl_platform(self, env):
         if self.spec.variants["host_platform"].value == "unset":
@@ -666,6 +713,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if self.spec.satisfies("+developer"):
             env.set("CHPL_DEVELOPER", "true")
+        else:
+            # CHPL_DEVELOPER needs to be unset, the value "False" is mishandled
+            env.unset("CHPL_DEVELOPER")
 
         if not self.spec.satisfies("llvm=none"):
             # workaround Spack issue #44746:
@@ -688,8 +738,10 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if self.spec.variants["hwloc"].value == "spack":
             self.update_lib_path(env, self.spec["hwloc"].prefix)
-            # Need this for the test env, where it does not appear automatic:
-            env.prepend_path("PKG_CONFIG_PATH", self.spec["libpciaccess"].prefix.lib.pkgconfig)
+            # Need hwloc opt deps for test env, where it does not appear automatic:
+            for dep in ["libpciaccess", "libxml2"]:
+                if dep in self.spec:
+                    self.update_lib_path(env, self.spec[dep].prefix)
 
         # TODO: unwind builds but resulting binaries fail to run, producing linker errors
         if self.spec.variants["unwind"].value == "spack":
@@ -736,23 +788,73 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     def setup_run_environment(self, env):
         self.setup_env_vars(env)
-        env.prepend_path(
-            "PATH", join_path(self.prefix.share, "chapel", self._output_version_short, "util")
+        chpl_home = join_path(self.prefix.share, "chapel", self._output_version_short)
+        env.prepend_path("PATH", join_path(chpl_home, "util"))
+        env.set(
+            "CHPL_MAKE_THIRD_PARTY",
+            join_path(self.prefix.lib, "chapel", self._output_version_short),
         )
+        # Lets not set it - if we use environment this fails to find
+        # correct location and there is autodetection anyway.
+        #env.set("CHPL_HOME", chpl_home)
+        # Set sensible default for this. Otherwise Slurm runs out of memory
+        # due to cgroup.
+        env.set("CHPL_RT_MAX_HEAP_SIZE", "10g")
+
+    def get_chpl_version_from_cmakelists(self) -> str:
+        cmake_lists = None
+        if os.path.exists(join_path(self.prefix.share, "chapel", "CMakeLists.txt")):
+            cmake_lists = join_path(self.prefix.share, "chapel", "CMakeLists.txt")
+        else:
+            cmake_lists = join_path(self.build_directory, "CMakeLists.txt")
+        assert cmake_lists is not None and os.path.exists(cmake_lists)
+        with open(cmake_lists, "r") as f:
+            # read CMakeLists.txt to get the CHPL_MAJOR_VERSION and CHPL_MINOR_VERSION
+            # and then construct the path from that
+            chpl_major_version = None
+            chpl_minor_version = None
+            chpl_patch_version = None
+            for line in f:
+                if "set(CHPL_MAJOR_VERSION" in line:
+                    chpl_major_version = line.split()[1].strip(")")
+                if "set(CHPL_MINOR_VERSION" in line:
+                    chpl_minor_version = line.split()[1].strip(")")
+                if "set(CHPL_PATCH_VERSION" in line:
+                    chpl_patch_version = line.split()[1].strip(")")
+                if (
+                    chpl_major_version is not None
+                    and chpl_minor_version is not None
+                    and chpl_patch_version is not None
+                ):
+                    break
+        assert (
+            chpl_major_version is not None
+            and chpl_minor_version is not None
+            and chpl_patch_version is not None
+        )
+        chpl_version_string = "{}.{}.{}".format(
+            chpl_major_version, chpl_minor_version, chpl_patch_version
+        )
+        return chpl_version_string
+
+    def is_versioned_release(self) -> bool:
+        # detect main or possibly other branch names
+        matches = re.findall(r"[^0-9.]", str(self.spec.version))
+        return len(matches) == 0
 
     @property
     @llnl.util.lang.memoized
-    def _output_version_long(self):
-        if str(self.spec.version).lower() == "main":
-            return "2.3.0"
+    def _output_version_long(self) -> str:
+        if not self.is_versioned_release():
+            return self.get_chpl_version_from_cmakelists()
         spec_vers_str = str(self.spec.version.up_to(3))
         return spec_vers_str
 
     @property
     @llnl.util.lang.memoized
-    def _output_version_short(self):
-        if str(self.spec.version).lower() == "main":
-            return "2.3"
+    def _output_version_short(self) -> str:
+        if not self.is_versioned_release():
+            return ".".join(self.get_chpl_version_from_cmakelists().split(".")[:-1])
         spec_vers_str = str(self.spec.version.up_to(2))
         return spec_vers_str
 
@@ -806,7 +908,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         """Run the hello world test"""
         with working_dir(self.test_suite.current_test_cache_dir):
             with set_env(CHPL_CHECK_HOME=self.test_suite.current_test_cache_dir):
-                with test_part(self, "test_hello", purpose="test hello world"):
+                with test_part(self, "test_hello_checkChplInstall", purpose="test hello world"):
                     if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
                         with set_env(COMP_FLAGS="--no-checks --no-compiler-driver"):
                             res = self.check_chpl_install()
@@ -826,85 +928,18 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             # TODO: Need to update checkChplDoc to work in the spack testing environment
             pass
 
-    # TODO: In order to run these tests, there's a lot of infrastructure to copy
-    # from the Chapel test suite and there are conflicts with CHPL_HOME needing
-    # to match the compiler's directory and the test suite's directory
-    # def test_package_modules(self):
-    #     """Test that the package modules are available"""
-    #     # if not self.spec.satisfies("+module_tests"):
-    #     #     print("Skipping module tests as module_tests variant is not set")
-    #     #     return
-    #     tests_to_run = []
-    #     with working_dir(self.test_suite.current_test_cache_dir):
-    #         with set_env(CHPL_HOME=join_path(self.spec.prefix.share,
-    #                      "chapel", self._output_version_short)):
-    #             with test_part(self, "test_package_modules", purpose="test package modules"):
-    #                 if self.spec.satisfies("+yaml"):
-    #                     tests_to_run.append("test/library/packages/Yaml/writeAndParse.chpl")
-    #                 if self.spec.satisfies("+zmq"):
-    #                     tests_to_run.append("test/library/packages/ZMQ/weather.chpl")
-    #                 if self.spec.satisfies("+ssl"):
-    #                     tests_to_run.append("test/library/packages/Crypto/")
-    #                 # TODO: These tests fail with llvm, unable to find C variable CURLPAUSE_CONT
-    #                 if (
-    #                     self.spec.satisfies("+curl")
-    #                     and self.spec.variants["llvm"].value == "none"
-    #                 ):
-    #                     with set_env(CHPL_NIGHTLY_TEST_CONFIG_NAME="networking-packages"):
-    #                         print("Running package module test for package 'curl'")
-    #                         res = subprocess.run(
-    #                             ["util/start_test", "test/library/packages/Curl/"]
-    #                         )
-    #                         assert res.returncode == 0
-    #                         print("Running package module test for package 'url'")
-    #                         res = subprocess.run(["util/start_test",
-    #                                               "test/library/packages/URL/"])
-    #                         assert res.returncode == 0
-    #                 if self.spec.satisfies("+hdf5"):
-    #                     tests_to_run.append("test/library/packages/HDF5/")
-    #                 if self.spec.satisfies("+protobuf"):
-    #                     tests_to_run.append("test/library/packages/ProtobufProtocolSupport/")
-    #                 if len(tests_to_run) > 0:
-    #                     with set_env(CHPL_HOME=self.test_suite.current_test_cache_dir):
-    #                         compiler = join_path(self.spec.prefix.bin,'chpl')
-    #                         print("Running package module tests for packages...")
-    #                         print(f" command to run: util/start_test --compiler {compiler}")
-    #                         tests_to_run.insert(0, "util/start_test")
-    #                         tests_to_run.insert(1, "--compiler")
-    #                         tests_to_run.insert(2, compiler)
-    #                         res = subprocess.run([t for t in tests_to_run])
-    #                         assert res.returncode == 0
-
     @run_after("install")
     def copy_test_files(self):
         """Copy test files to the install directory"""
         test_files = [
-            "test/release/examples",
+            "examples/",
             "util/start_test",
             "util/test",
             "util/chplenv",
             "util/config",
             "util/printchplenv",
-            #   "test/library/packages/Curl",
-            #   "test/library/packages/URL/",
-            #   "test/library/packages/ProtobufProtocolSupport/",
-            #   "test/library/packages/Crypto/",
-            #   "test/library/packages/Yaml/",
-            #   "test/library/packages/ZMQ/",
-            #   "test/library/packages/HDF5/",
             "chplconfig",
             "make",
             "third-party/chpl-venv/",
         ]
         cache_extra_test_sources(self, test_files)
-
-    # @run_after("install")
-    # @on_package_attributes(run_tests=True)
-    # def self_check(self):
-    #     """Run the self-check after installing the package"""
-    #     path_put_first("PATH", [self.prefix.bin])
-    #     self.test_version()
-    #     self.test_hello()
-    #     if self.spec.satisfies("+chpldoc"):
-    #       make("check-chpldoc")
-    #     self.test_package_modules()


### PR DESCRIPTION
Some environment variables were required to make it work with Slurm.  libfabric seems to set default heap size which hits Slurm cgroup memory limit.  Reduce limit using environment variable in Spack package.

Also do not set `CHPL_HOME` since this breaks in Spack environments since it tries to match paths and has fixed idea where install location is.  Not setting seems to work.