### PR TITLE
Update OpenMPI to make 4.1.8 available.

### DIFF
--- a/repo/v0.23/isamrepo/packages/openmpi/accelerator-build-components-as-dso-s-by-default.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/accelerator-build-components-as-dso-s-by-default.patch
@@ -1,0 +1,81 @@
+From 7e2e390e468db44c8540d2510841a22d146fa6ed Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <howardp@lanl.gov>
+Date: Tue, 7 Nov 2023 10:06:47 -0500
+Subject: [PATCH] accelerator: build components as dso's by default
+
+also need to switch rcache/gpsum and rcache/rgpusum
+
+to DSO by default.
+
+Fix a problem in opal_mca.m4 where the enable-mca-dso list wasn't being
+processed correctly starting with 5.0.0.
+
+related to #12036
+
+Signed-off-by: Howard Pritchard <howardp@lanl.gov>
+
+diff --git a/config/opal_mca.m4 b/config/opal_mca.m4
+index 935b8c65..b425fe63 100644
+--- a/config/opal_mca.m4
++++ b/config/opal_mca.m4
+@@ -13,7 +13,7 @@ dnl                         All rights reserved.
+ dnl Copyright (c) 2010-2021 Cisco Systems, Inc.  All rights reserved
+ dnl Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ dnl Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+-dnl Copyright (c) 2021      Triad National Security, LLC. All rights
++dnl Copyright (c) 2021-2023 Triad National Security, LLC. All rights
+ dnl                         reserved.
+ dnl $COPYRIGHT$
+ dnl
+@@ -167,6 +167,9 @@ of type-component pairs.  For example, --enable-mca-no-build=pml-ob1])
+     # Second, set the DSO_all and STATIC_all variables.  conflict
+     # resolution (prefer static) is done in the big loop below
+     #
++    # Exception here is the components of the accelerator framework,
++    # which by default are built to be dynamic, except for null.
++    #
+     AC_MSG_CHECKING([which components should be run-time loadable])
+     if test "$enable_static" != "no"; then
+         DSO_all=0
+@@ -174,9 +177,6 @@ of type-component pairs.  For example, --enable-mca-no-build=pml-ob1])
+     elif test "$OPAL_ENABLE_DLOPEN_SUPPORT" = 0; then
+         DSO_all=0
+         msg="none (dlopen disabled)"
+-    elif test -z "$enable_mca_dso"; then
+-        DSO_all=0
+-        msg=default
+     elif test "$enable_mca_dso" = "no"; then
+         DSO_all=0
+         msg=none
+@@ -184,15 +184,19 @@ of type-component pairs.  For example, --enable-mca-no-build=pml-ob1])
+         DSO_all=1
+         msg=all
+     else
+-        DSO_all=0
+-        ifs_save="$IFS"
+-        IFS="${IFS}$PATH_SEPARATOR,"
+-        msg=
+-        for item in $enable_mca_dso; do
+-            AS_VAR_SET([AS_TR_SH([DSO_$item])], [1])
+-            msg="$item $msg"
+-        done
+-        IFS="$ifs_save"
++       msg=
++       if test -z "$enable_mca_dso"; then
++           enable_mca_dso="accelerator-cuda,accelerator-rocm,accelerator-ze,btl-smcuda,rcache-gpusm,rcache-rgpusm"
++           msg="(default)"
++       fi
++       DSO_all=0
++       ifs_save="$IFS"
++       IFS="${IFS}$PATH_SEPARATOR,"
++       for item in $enable_mca_dso; do
++           AS_VAR_SET([AS_TR_SH([DSO_$item])], [1])
++           msg="$item $msg"
++       done
++       IFS="$ifs_save"
+     fi
+     AC_MSG_RESULT([$msg])
+     unset msg
+-- 
+2.35.3
+

--- a/repo/v0.23/isamrepo/packages/openmpi/accelerator-cuda-fix-bug-in-makefile.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/accelerator-cuda-fix-bug-in-makefile.patch
@@ -1,0 +1,33 @@
+From be28fa6421094fcd0c544a6d457c6d748670959a Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <howardp@lanl.gov>
+Date: Mon, 13 Nov 2023 08:12:28 -0700
+Subject: [PATCH] accelerator/cuda: fix bug in makefile.am
+
+that prevents correct linkage of libcuda.so if it is in
+a non standard location.
+
+Related to https://github.com/spack/spack/pull/40913
+
+Signed-off-by: Howard Pritchard <howardp@lanl.gov>
+
+diff --git a/opal/mca/accelerator/cuda/Makefile.am b/opal/mca/accelerator/cuda/Makefile.am
+index 5646890b..2c533ece 100644
+--- a/opal/mca/accelerator/cuda/Makefile.am
++++ b/opal/mca/accelerator/cuda/Makefile.am
+@@ -34,11 +34,11 @@ mcacomponentdir = $(opallibdir)
+ mcacomponent_LTLIBRARIES = $(component_install)
+ 
+ mca_accelerator_cuda_la_SOURCES = $(sources)
+-mca_accelerator_cuda_la_LDFLAGS = -module -avoid-version
++mca_accelerator_cuda_la_LDFLAGS = -module -avoid-version $(accelerator_cuda_LDFLAGS)
+ mca_accelerator_cuda_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+         $(accelerator_cuda_LIBS)
+ 
+ noinst_LTLIBRARIES = $(component_noinst)
+ libmca_accelerator_cuda_la_SOURCES =$(sources)
+-libmca_accelerator_cuda_la_LDFLAGS = -module -avoid-version
++libmca_accelerator_cuda_la_LDFLAGS = -module -avoid-version $(accelerator_cuda_LDFLAGS)
+ libmca_accelerator_cuda_la_LIBADD = $(accelerator_cuda_LIBS)
+-- 
+2.35.3
+

--- a/repo/v0.23/isamrepo/packages/openmpi/ad_lustre_rwcontig_open_source.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/ad_lustre_rwcontig_open_source.patch
@@ -1,0 +1,11 @@
+--- a/ompi/mca/io/romio/romio/adio/ad_lustre/ad_lustre_rwcontig.c	2013-12-10 12:05:44.806417000 -0800
++++ b/ompi/mca/io/romio/romio/adio/ad_lustre/ad_lustre_rwcontig.c	2013-12-10 11:53:03.295622000 -0800
+@@ -8,7 +8,7 @@
+  *   Copyright (C) 2008 Sun Microsystems, Lustre group
+  */
+ 
+-#define _XOPEN_SOURCE 600
++//#define _XOPEN_SOURCE 600
+ #include <stdlib.h>
+ #include <malloc.h>
+ #include "ad_lustre.h"

--- a/repo/v0.23/isamrepo/packages/openmpi/btl_vader.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/btl_vader.patch
@@ -1,0 +1,24 @@
+diff --git a/opal/mca/btl/vader/btl_vader_fbox.h b/opal/mca/btl/vader/btl_vader_fbox.h
+index 17239ce8ef..ee5c913551 100644
+--- a/opal/mca/btl/vader/btl_vader_fbox.h
++++ b/opal/mca/btl/vader/btl_vader_fbox.h
+@@ -138,9 +138,6 @@ static inline bool mca_btl_vader_fbox_sendi (mca_btl_base_endpoint_t *ep, unsign
+         memcpy (data + header_size, payload, payload_size);
+     }
+ 
+-    /* write out part of the header now. the tag will be written when the data is available */
+-    mca_btl_vader_fbox_set_header (MCA_BTL_VADER_FBOX_HDR(dst), tag, ep->fbox_out.seq++, data_size);
+-
+     end += size;
+ 
+     if (OPAL_UNLIKELY(fbox_size == end)) {
+@@ -152,6 +149,9 @@ static inline bool mca_btl_vader_fbox_sendi (mca_btl_base_endpoint_t *ep, unsign
+         MCA_BTL_VADER_FBOX_HDR(ep->fbox_out.buffer + end)->ival = 0;
+     }
+ 
++    /* write out part of the header now. the tag will be written when the data is available */
++    mca_btl_vader_fbox_set_header (MCA_BTL_VADER_FBOX_HDR(dst), tag, ep->fbox_out.seq++, data_size);
++
+     /* align the buffer */
+     ep->fbox_out.end = ((uint32_t) hbs << 31) | end;
+     opal_atomic_wmb ();

--- a/repo/v0.23/isamrepo/packages/openmpi/btlsmcuda-fix-problem-with-makefile.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/btlsmcuda-fix-problem-with-makefile.patch
@@ -1,0 +1,73 @@
+From 27672784304d4c944e2e3c7d526dfd77f021a113 Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <howardp@lanl.gov>
+Date: Thu, 16 Nov 2023 07:05:01 -0700
+Subject: [PATCH] btlsmcuda: fix problem with makefile
+
+when libcuda.so is in a non-standard location.
+
+also fix rcache/gpusm and rcache/rgpsum
+
+Similar fix to that in #12065
+
+Signed-off-by: Howard Pritchard <howardp@lanl.gov>
+
+diff --git a/opal/mca/btl/smcuda/Makefile.am b/opal/mca/btl/smcuda/Makefile.am
+index f1a89df8..8ee37add 100644
+--- a/opal/mca/btl/smcuda/Makefile.am
++++ b/opal/mca/btl/smcuda/Makefile.am
+@@ -51,7 +51,7 @@ endif
+ mcacomponentdir = $(opallibdir)
+ mcacomponent_LTLIBRARIES = $(component_install)
+ mca_btl_smcuda_la_SOURCES = $(libmca_btl_smcuda_la_sources)
+-mca_btl_smcuda_la_LDFLAGS = -module -avoid-version
++mca_btl_smcuda_la_LDFLAGS = -module -avoid-version $(btl_smcuda_LDFLAGS)
+ mca_btl_smcuda_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+     $(OPAL_TOP_BUILDDIR)/opal/mca/common/sm/lib@OPAL_LIB_NAME@mca_common_sm.la \
+     $(btl_smcuda_LIBS)
+@@ -59,6 +59,6 @@ mca_btl_smcuda_la_CPPFLAGS = $(btl_smcuda_CPPFLAGS)
+ 
+ noinst_LTLIBRARIES = $(component_noinst)
+ libmca_btl_smcuda_la_SOURCES = $(libmca_btl_smcuda_la_sources)
+-libmca_btl_smcuda_la_LDFLAGS = -module -avoid-version
++libmca_btl_smcuda_la_LDFLAGS = -module -avoid-version $(btl_smcuda_LDFLAGS)
+ libmca_btl_smcuda_la_CPPFLAGS = $(btl_smcuda_CPPFLAGS)
+ libmca_btl_smcuda_la_LIBADD = $(btl_smcuda_LIBS)
+diff --git a/opal/mca/rcache/gpusm/Makefile.am b/opal/mca/rcache/gpusm/Makefile.am
+index 5645e5ea..1ff63b35 100644
+--- a/opal/mca/rcache/gpusm/Makefile.am
++++ b/opal/mca/rcache/gpusm/Makefile.am
+@@ -48,11 +48,11 @@ endif
+ mcacomponentdir = $(opallibdir)
+ mcacomponent_LTLIBRARIES = $(component_install)
+ mca_rcache_gpusm_la_SOURCES = $(sources)
+-mca_rcache_gpusm_la_LDFLAGS = -module -avoid-version
++mca_rcache_gpusm_la_LDFLAGS = -module -avoid-version $(rcache_gpusm_LDFLAGS)
+ mca_rcache_gpusm_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+ 	$(rcache_gpusm_LIBS)
+ 
+ noinst_LTLIBRARIES = $(component_noinst)
+ libmca_rcache_gpusm_la_SOURCES = $(sources)
+-libmca_rcache_gpusm_la_LDFLAGS = -module -avoid-version
++libmca_rcache_gpusm_la_LDFLAGS = -module -avoid-version $(rcache_gpusm_LDFLAGS)
+ libmca_rcache_gpusm_la_LIBADD = $(rcache_gpusm_LIBS)
+diff --git a/opal/mca/rcache/rgpusm/Makefile.am b/opal/mca/rcache/rgpusm/Makefile.am
+index 6d2fdbc3..dde81411 100644
+--- a/opal/mca/rcache/rgpusm/Makefile.am
++++ b/opal/mca/rcache/rgpusm/Makefile.am
+@@ -46,11 +46,11 @@ endif
+ mcacomponentdir = $(opallibdir)
+ mcacomponent_LTLIBRARIES = $(component_install)
+ mca_rcache_rgpusm_la_SOURCES = $(sources)
+-mca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version
++mca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version $(rcache_rgpusm_LDFLAGS)
+ mca_rcache_rgpusm_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la \
+ 	$(rcache_rgpusm_LIBS)
+ 
+ noinst_LTLIBRARIES = $(component_noinst)
+ libmca_rcache_rgpusm_la_SOURCES = $(sources)
+-libmca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version
++libmca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version $(rcache_rgpusm_LDFLAGS)
+ libmca_rcache_rgpusm_la_LIBADD = $(rcache_rgpusm_LIBS)
+-- 
+2.35.3
+

--- a/repo/v0.23/isamrepo/packages/openmpi/configure.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/configure.patch
@@ -1,0 +1,31 @@
+This patch addresses <https://github.com/open-mpi/ompi/issues/576>.
+--- a/configure
++++ b/configure
+@@ -301130,10 +301130,11 @@
+     case ${prev}${p} in
+ 
+     -L* | -R* | -l*)
+-       # Some compilers place space between "-{L,R}" and the path.
++       # Some compilers place space between "-{L,R,l}" and the path.
+        # Remove the space.
+        if test $p = "-L" ||
+-          test $p = "-R"; then
++          test $p = "-R" ||
++          test $p = "-l"; then
+ 	 prev=$p
+ 	 continue
+        fi
+@@ -303036,10 +303037,11 @@
+     case ${prev}${p} in
+ 
+     -L* | -R* | -l*)
+-       # Some compilers place space between "-{L,R}" and the path.
++       # Some compilers place space between "-{L,R,l}" and the path.
+        # Remove the space.
+        if test $p = "-L" ||
+-          test $p = "-R"; then
++          test $p = "-R" ||
++          test $p = "-l"; then
+ 	 prev=$p
+ 	 continue
+        fi

--- a/repo/v0.23/isamrepo/packages/openmpi/fix-for-dlopen-missing-symbol-problem.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/fix-for-dlopen-missing-symbol-problem.patch
@@ -1,0 +1,32 @@
+From 50731f03c1ae9d375bfc2771fc402d54fd22e276 Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <howardp@lanl.gov>
+Date: Sat, 4 Nov 2023 13:24:15 -0600
+Subject: [PATCH] spack:fix for dlopen missing symbol problem
+
+related to https://github.com/spack/spack/pull/40725
+
+Signed-off-by: Howard Pritchard <howardp@lanl.gov>
+
+diff --git a/opal/mca/dl/dlopen/configure.m4 b/opal/mca/dl/dlopen/configure.m4
+index 07fda82001..4ae625b1fb 100644
+--- a/opal/mca/dl/dlopen/configure.m4
++++ b/opal/mca/dl/dlopen/configure.m4
+@@ -27,7 +27,7 @@ AC_DEFUN([MCA_opal_dl_dlopen_CONFIG],[
+     AC_CONFIG_FILES([opal/mca/dl/dlopen/Makefile])
+ 
+     OAC_CHECK_PACKAGE([dlopen],
+-              [dl_dlopen],
++              [opal_dl_dlopen],
+               [dlfcn.h],
+               [dl],
+               [dlopen],
+@@ -38,5 +38,5 @@ AC_DEFUN([MCA_opal_dl_dlopen_CONFIG],[
+           [$1],
+           [$2])
+ 
+-    AC_SUBST(dl_dlopen_LIBS)
++    AC_SUBST(opal_dl_dlopen_LIBS)
+ ])
+-- 
+2.39.3
+

--- a/repo/v0.23/isamrepo/packages/openmpi/fix-ucx-1.7.0-api-instability.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/fix-ucx-1.7.0-api-instability.patch
@@ -1,0 +1,254 @@
+diff --git a/opal/mca/btl/uct/btl_uct.h b/opal/mca/btl/uct/btl_uct.h
+index 3875679443..0e4ec9a949 100644
+--- a/opal/mca/btl/uct/btl_uct.h
++++ b/opal/mca/btl/uct/btl_uct.h
+@@ -12,6 +12,7 @@
+  *                         All rights reserved.
+  * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
+  *                         reserved.
++ * Copyright (c) 2019      Google, LLC. All rights reserved.
+  * $COPYRIGHT$
+  *
+  * Additional copyrights may follow
+@@ -85,6 +86,10 @@ struct mca_btl_uct_module_t {
+     /** array containing the am_tl and rdma_tl */
+     mca_btl_uct_tl_t *comm_tls[2];
+ 
++#if UCT_API >= UCT_VERSION(1, 7)
++    uct_component_h uct_component;
++#endif
++
+     /** registration cache */
+     mca_rcache_base_module_t *rcache;
+ 
+diff --git a/opal/mca/btl/uct/btl_uct_amo.c b/opal/mca/btl/uct/btl_uct_amo.c
+index f7d0232688..72398ce736 100644
+--- a/opal/mca/btl/uct/btl_uct_amo.c
++++ b/opal/mca/btl/uct/btl_uct_amo.c
+@@ -110,7 +110,7 @@ int mca_btl_uct_afop (struct mca_btl_base_module_t *btl, struct mca_btl_base_end
+         mca_btl_uct_uct_completion_release (comp);
+     }
+ 
+-    uct_rkey_release (&rkey);
++    mca_btl_uct_rkey_release (uct_btl, &rkey);
+ 
+     return rc;
+ }
+@@ -184,7 +184,7 @@ int mca_btl_uct_acswap (struct mca_btl_base_module_t *btl, struct mca_btl_base_e
+         mca_btl_uct_uct_completion_release (comp);
+     }
+ 
+-    uct_rkey_release (&rkey);
++    mca_btl_uct_rkey_release (uct_btl, &rkey);
+ 
+     return rc;
+ }
+diff --git a/opal/mca/btl/uct/btl_uct_component.c b/opal/mca/btl/uct/btl_uct_component.c
+index f968cb9c31..bff160736b 100644
+--- a/opal/mca/btl/uct/btl_uct_component.c
++++ b/opal/mca/btl/uct/btl_uct_component.c
+@@ -314,7 +314,12 @@ ucs_status_t mca_btl_uct_am_handler (void *arg, void *data, size_t length, unsig
+     return UCS_OK;
+ }
+ 
++#if UCT_API >= UCT_VERSION(1, 7)
++static int mca_btl_uct_component_process_uct_md (uct_component_h component, uct_md_resource_desc_t *md_desc,
++                                                 char **allowed_ifaces)
++#else
+ static int mca_btl_uct_component_process_uct_md (uct_md_resource_desc_t *md_desc, char **allowed_ifaces)
++#endif
+ {
+     mca_rcache_base_resources_t rcache_resources;
+     uct_tl_resource_desc_t *tl_desc;
+@@ -348,8 +353,14 @@ static int mca_btl_uct_component_process_uct_md (uct_md_resource_desc_t *md_desc
+ 
+     md = OBJ_NEW(mca_btl_uct_md_t);
+ 
++
++#if UCT_API >= UCT_VERSION(1, 7)
++    uct_md_config_read (component, NULL, NULL, &uct_config);
++    uct_md_open (component, md_desc->md_name, uct_config, &md->uct_md);
++#else
+     uct_md_config_read (md_desc->md_name, NULL, NULL, &uct_config);
+     uct_md_open (md_desc->md_name, uct_config, &md->uct_md);
++#endif
+     uct_config_release (uct_config);
+ 
+     uct_md_query (md->uct_md, &md_attr);
+@@ -375,6 +386,10 @@ static int mca_btl_uct_component_process_uct_md (uct_md_resource_desc_t *md_desc
+         return OPAL_ERR_NOT_AVAILABLE;
+     }
+ 
++#if UCT_API >= UCT_VERSION(1, 7)
++    module->uct_component = component;
++#endif
++
+     mca_btl_uct_component.modules[mca_btl_uct_component.module_count++] = module;
+ 
+     /* NTH: a registration cache shouldn't be necessary when using UCT but there are measurable
+@@ -400,6 +415,42 @@ static int mca_btl_uct_component_process_uct_md (uct_md_resource_desc_t *md_desc
+     return OPAL_SUCCESS;
+ }
+ 
++#if UCT_API >= UCT_VERSION(1, 7)
++static int mca_btl_uct_component_process_uct_component (uct_component_h component, char **allowed_ifaces)
++{
++    uct_component_attr_t attr = {.field_mask = UCT_COMPONENT_ATTR_FIELD_NAME |
++                                 UCT_COMPONENT_ATTR_FIELD_MD_RESOURCE_COUNT};
++    ucs_status_t ucs_status;
++    int rc;
++
++    ucs_status = uct_component_query (component, &attr);
++    if (UCS_OK != ucs_status) {
++        return OPAL_ERROR;
++    }
++
++    BTL_VERBOSE(("processing uct component %s", attr.name));
++
++    attr.md_resources = calloc (attr.md_resource_count, sizeof (*attr.md_resources));
++    attr.field_mask |= UCT_COMPONENT_ATTR_FIELD_MD_RESOURCES;
++    ucs_status = uct_component_query (component, &attr);
++    if (UCS_OK != ucs_status) {
++        return OPAL_ERROR;
++    }
++
++    for (int i = 0 ; i < attr.md_resource_count ; ++i) {
++        rc = mca_btl_uct_component_process_uct_md (component, attr.md_resources + i,
++                                                   allowed_ifaces);
++        if (OPAL_SUCCESS != rc) {
++            break;
++        }
++    }
++
++    free (attr.md_resources);
++
++    return OPAL_SUCCESS;
++}
++#endif /* UCT_API >= UCT_VERSION(1, 7) */
++
+ /*
+  *  UCT component initialization:
+  *  (1) read interface list from kernel and compare against component parameters
+@@ -415,6 +466,7 @@ static mca_btl_base_module_t **mca_btl_uct_component_init (int *num_btl_modules,
+     struct mca_btl_base_module_t **base_modules;
+     uct_md_resource_desc_t *resources;
+     unsigned resource_count;
++    ucs_status_t ucs_status;
+     char **allowed_ifaces;
+     int rc;
+ 
+@@ -431,10 +483,32 @@ static mca_btl_base_module_t **mca_btl_uct_component_init (int *num_btl_modules,
+         return NULL;
+     }
+ 
+-    uct_query_md_resources (&resources, &resource_count);
+-
+     mca_btl_uct_component.module_count = 0;
+ 
++#if UCT_API >= UCT_VERSION(1, 7)
++    uct_component_h *components;
++    unsigned num_components;
++
++    ucs_status = uct_query_components(&components, &num_components);
++    if (UCS_OK != ucs_status) {
++        BTL_ERROR(("could not query UCT components"));
++        return NULL;
++    }
++
++    /* generate all suitable btl modules */
++    for (unsigned i = 0 ; i < num_components ; ++i) {
++        rc = mca_btl_uct_component_process_uct_component (components[i], allowed_ifaces);
++        if (OPAL_SUCCESS != rc) {
++            break;
++        }
++    }
++
++    uct_release_component_list (components);
++
++#else /* UCT 1.6 and older */
++
++    uct_query_md_resources (&resources, &resource_count);
++
+     /* generate all suitable btl modules */
+     for (unsigned i = 0 ; i < resource_count ; ++i) {
+         rc = mca_btl_uct_component_process_uct_md (resources + i, allowed_ifaces);
+@@ -443,9 +517,11 @@ static mca_btl_base_module_t **mca_btl_uct_component_init (int *num_btl_modules,
+         }
+     }
+ 
+-    opal_argv_free (allowed_ifaces);
+     uct_release_md_resource_list (resources);
+ 
++#endif /* UCT_API >= UCT_VERSION(1, 7) */
++
++    opal_argv_free (allowed_ifaces);
+     mca_btl_uct_modex_send ();
+ 
+     /* pass module array back to caller */
+diff --git a/opal/mca/btl/uct/btl_uct_rdma.c b/opal/mca/btl/uct/btl_uct_rdma.c
+index 2d2d1c3f04..9ee9530f26 100644
+--- a/opal/mca/btl/uct/btl_uct_rdma.c
++++ b/opal/mca/btl/uct/btl_uct_rdma.c
+@@ -132,7 +132,7 @@ int mca_btl_uct_get (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
+ 
+     BTL_VERBOSE(("get issued. status = %d", ucs_status));
+ 
+-    uct_rkey_release (&rkey);
++    mca_btl_uct_rkey_release (uct_btl, &rkey);
+ 
+     return OPAL_LIKELY(UCS_OK == ucs_status) ? OPAL_SUCCESS : OPAL_ERR_RESOURCE_BUSY;
+ }
+@@ -237,7 +237,7 @@ int mca_btl_uct_put (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
+         mca_btl_uct_uct_completion_release (comp);
+     }
+ 
+-    uct_rkey_release (&rkey);
++    mca_btl_uct_rkey_release (uct_btl, &rkey);
+ 
+     return OPAL_LIKELY(UCS_OK == ucs_status) ? OPAL_SUCCESS : OPAL_ERR_RESOURCE_BUSY;
+ }
+diff --git a/opal/mca/btl/uct/btl_uct_rdma.h b/opal/mca/btl/uct/btl_uct_rdma.h
+index e9b0d6b19d..ab790371af 100644
+--- a/opal/mca/btl/uct/btl_uct_rdma.h
++++ b/opal/mca/btl/uct/btl_uct_rdma.h
+@@ -55,8 +55,22 @@ static inline int mca_btl_uct_get_rkey (mca_btl_uct_module_t *module,
+         return rc;
+     }
+ 
++#if UCT_API >= UCT_VERSION(1, 7)
++    ucs_status = uct_rkey_unpack (module->uct_component, (void *) remote_handle, rkey);
++#else
+     ucs_status = uct_rkey_unpack ((void *) remote_handle, rkey);
++#endif
+     return (UCS_OK == ucs_status) ? OPAL_SUCCESS : OPAL_ERROR;
+ }
+ 
++static inline void mca_btl_uct_rkey_release (mca_btl_uct_module_t *uct_btl, uct_rkey_bundle_t *rkey)
++{
++#if UCT_API >= UCT_VERSION(1, 7)
++    uct_rkey_release (uct_btl->uct_component, rkey);
++#else
++    (void) uct_btl;
++    uct_rkey_release (rkey);
++#endif
++}
++
+ #endif /* !defined(BTL_UCT_RDMA_H) */
+diff --git a/opal/mca/btl/uct/btl_uct_tl.c b/opal/mca/btl/uct/btl_uct_tl.c
+index a711a41ce9..e69c769b41 100644
+--- a/opal/mca/btl/uct/btl_uct_tl.c
++++ b/opal/mca/btl/uct/btl_uct_tl.c
+@@ -516,7 +516,13 @@ static int mca_btl_uct_evaluate_tl (mca_btl_uct_module_t *module, mca_btl_uct_tl
+ 	 * come up with a better estimate. */
+ 
+ 	/* UCT bandwidth is in bytes/sec, BTL is in MB/sec */
++#if UCT_API >= UCT_VERSION(1, 7)
++	module->super.btl_bandwidth = (uint32_t) ((MCA_BTL_UCT_TL_ATTR(tl, 0).bandwidth.dedicated +
++                                                   MCA_BTL_UCT_TL_ATTR(tl, 0).bandwidth.shared /
++                                                   (opal_process_info.num_local_peers + 1)) / 1048576.0);
++#else
+ 	module->super.btl_bandwidth = (uint32_t) (MCA_BTL_UCT_TL_ATTR(tl, 0).bandwidth / 1048576.0);
++#endif
+ 	/* TODO -- figure out how to translate UCT latency to us */
+ 	module->super.btl_latency = 1;
+     }

--- a/repo/v0.23/isamrepo/packages/openmpi/fix_multidef_pmi_class.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/fix_multidef_pmi_class.patch
@@ -1,0 +1,54 @@
+diff -Naur openmpi-2.0.1.orig/opal/mca/pmix/cray/pmix_cray.c openmpi-2.0.1/opal/mca/pmix/cray/pmix_cray.c
+--- openmpi-2.0.1.orig/opal/mca/pmix/cray/pmix_cray.c	2016-08-23 04:56:37.000000000 +0800
++++ openmpi-2.0.1/opal/mca/pmix/cray/pmix_cray.c	2017-01-31 01:05:34.302807465 +0800
+@@ -6,7 +6,7 @@
+  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All
+  *                         rights reserved.
+  * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
+- * Copyright (c) 2014-2015 Research Organization for Information Science
++ * Copyright (c) 2014-2016 Research Organization for Information Science
+  *                         and Technology (RIST). All rights reserved.
+  * $COPYRIGHT$
+  *
+@@ -127,7 +127,7 @@
+     opal_pmix_op_cbfunc_t opcbfunc;
+     void *cbdata;
+ } pmi_opcaddy_t;
+-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
++static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+                    opal_object_t,
+                    NULL, NULL);
+ 
+diff -Naur openmpi-2.0.1.orig/opal/mca/pmix/s1/pmix_s1.c openmpi-2.0.1/opal/mca/pmix/s1/pmix_s1.c
+--- openmpi-2.0.1.orig/opal/mca/pmix/s1/pmix_s1.c	2016-08-23 04:56:37.000000000 +0800
++++ openmpi-2.0.1/opal/mca/pmix/s1/pmix_s1.c	2017-01-31 01:06:08.014808847 +0800
+@@ -1,7 +1,7 @@
+ /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+ /*
+  * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+- * Copyright (c) 2014-2015 Research Organization for Information Science
++ * Copyright (c) 2014-2016 Research Organization for Information Science
+  *                         and Technology (RIST). All rights reserved.
+  * $COPYRIGHT$
+  *
+@@ -88,7 +88,7 @@
+     opal_pmix_op_cbfunc_t opcbfunc;
+     void *cbdata;
+ } pmi_opcaddy_t;
+-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
++static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+                    opal_object_t,
+                    NULL, NULL);
+ 
+diff -Naur openmpi-2.0.1.orig/opal/mca/pmix/s2/pmix_s2.c openmpi-2.0.1/opal/mca/pmix/s2/pmix_s2.c
+--- openmpi-2.0.1.orig/opal/mca/pmix/s2/pmix_s2.c	2016-08-23 04:56:37.000000000 +0800
++++ openmpi-2.0.1/opal/mca/pmix/s2/pmix_s2.c	2017-01-31 01:06:27.718809655 +0800
+@@ -95,7 +95,7 @@
+     opal_pmix_op_cbfunc_t opcbfunc;
+     void *cbdata;
+ } pmi_opcaddy_t;
+-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
++static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+                    opal_object_t,
+                    NULL, NULL);
+ 

--- a/repo/v0.23/isamrepo/packages/openmpi/llnl-platforms.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/llnl-platforms.patch
@@ -1,0 +1,151 @@
+diff -Nuar openmpi-1.6.5.orig/contrib/platform/llnl/optimized openmpi-1.6.5.llnl/contrib/platform/llnl/optimized
+--- openmpi-1.6.5.orig/contrib/platform/llnl/optimized	1969-12-31 16:00:00.000000000 -0800
++++ openmpi-1.6.5.llnl/contrib/platform/llnl/optimized	2013-08-08 23:47:12.704029000 -0700
+@@ -0,0 +1,29 @@
++enable_dlopen=no
++enable_mem_debug=no
++enable_mem_profile=no
++enable_debug_symbols=no
++enable_binaries=yes
++enable_heterogeneous=no
++enable_debug=no
++enable_shared=yes
++enable_static=yes
++enable_memchecker=no
++enable_ipv6=no
++enable_mpi_f77=yes
++enable_mpi_f90=yes
++enable_mpi_cxx=yes
++enable_mpi_cxx_seek=yes
++enable_cxx_exceptions=no
++enable_ft_thread=no
++enable_per_user_config_files=no
++enable_mca_no_build=carto,crs,filem,routed-linear,snapc,pml-dr,pml-crcp2,pml-crcpw,pml-v,pml-example,crcp,btl-tcp
++enable_contrib_no_build=libnbc,vt
++with_slurm=yes
++with_pmi=yes
++with_tm=no
++with_openib=yes
++with_psm=yes
++with_devel_headers=yes
++with_io_romio_flags=--with-file-system=ufs+nfs+lustre
++with_memory_manager=ptmalloc2
++with_valgrind=no
+diff -Nuar openmpi-1.6.5.orig/contrib/platform/llnl/optimized.conf openmpi-1.6.5.llnl/contrib/platform/llnl/optimized.conf
+--- openmpi-1.6.5.orig/contrib/platform/llnl/optimized.conf	1969-12-31 16:00:00.000000000 -0800
++++ openmpi-1.6.5.llnl/contrib/platform/llnl/optimized.conf	2013-08-08 23:43:52.907553000 -0700
+@@ -0,0 +1,114 @@
++#
++# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
++#                         University Research and Technology
++#                         Corporation.  All rights reserved.
++# Copyright (c) 2004-2005 The University of Tennessee and The University
++#                         of Tennessee Research Foundation.  All rights
++#                         reserved.
++# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
++#                         University of Stuttgart.  All rights reserved.
++# Copyright (c) 2004-2005 The Regents of the University of California.
++#                         All rights reserved.
++# Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
++# Copyright (c) 2011      Los Alamos National Security, LLC.
++#                         All rights reserved.
++# $COPYRIGHT$
++#
++# Additional copyrights may follow
++#
++# $HEADER$
++#
++
++# This is the default system-wide MCA parameters defaults file.
++# Specifically, the MCA parameter "mca_param_files" defaults to a
++# value of
++# "$HOME/.openmpi/mca-params.conf:$sysconf/openmpi-mca-params.conf"
++# (this file is the latter of the two).  So if the default value of
++# mca_param_files is not changed, this file is used to set system-wide
++# MCA parameters.  This file can therefore be used to set system-wide
++# default MCA parameters for all users.  Of course, users can override
++# these values if they want, but this file is an excellent location
++# for setting system-specific MCA parameters for those users who don't
++# know / care enough to investigate the proper values for them.
++
++# Note that this file is only applicable where it is visible (in a
++# filesystem sense).  Specifically, MPI processes each read this file
++# during their startup to determine what default values for MCA
++# parameters should be used.  mpirun does not bundle up the values in
++# this file from the node where it was run and send them to all nodes;
++# the default value decisions are effectively distributed.  Hence,
++# these values are only applicable on nodes that "see" this file.  If
++# $sysconf is a directory on a local disk, it is likely that changes
++# to this file will need to be propagated to other nodes.  If $sysconf
++# is a directory that is shared via a networked filesystem, changes to
++# this file will be visible to all nodes that share this $sysconf.
++
++# The format is straightforward: one per line, mca_param_name =
++# rvalue.  Quoting is ignored (so if you use quotes or escape
++# characters, they'll be included as part of the value).  For example:
++
++# Disable run-time MPI parameter checking
++#   mpi_param_check = 0
++
++# Note that the value "~/" will be expanded to the current user's home
++# directory.  For example:
++
++# Change component loading path
++#   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
++
++# See "ompi_info --param all all" for a full listing of Open MPI MCA
++# parameters available and their default values.
++#
++
++# Basic behavior to smooth startup
++mca_component_show_load_errors = 0
++orte_abort_timeout = 10
++opal_set_max_sys_limits = 1
++orte_report_launch_progress = 1
++
++# Define timeout for daemons to report back during launch
++orte_startup_timeout = 10000
++
++## Protect the shared file systems
++orte_no_session_dirs = /p,/usr/local,/usr/global,/nfs/tmp1,/nfs/tmp2
++orte_tmpdir_base = /tmp
++
++## Require an allocation to run - protects the frontend
++## from inadvertent job executions
++orte_allocation_required = 1
++
++## MPI behavior
++## Do NOT specify mpi_leave_pinned so system
++## can figure out for itself whether or not
++## it is supported and usable
++orte_notifier = syslog
++
++## Add the interface for out-of-band communication
++## and set it up
++oob_tcp_if_include=ib0
++oob_tcp_peer_retries = 1000
++oob_tcp_disable_family = IPv6
++oob_tcp_listen_mode = listen_thread
++oob_tcp_sndbuf = 32768
++oob_tcp_rcvbuf = 32768
++
++## Define the MPI interconnects
++btl = sm,openib,self
++
++## We are using the PSM MTL by default
++## There can only be one!
++pml = cm
++
++## Setup OpenIB - just in case
++btl_openib_want_fork_support = 0
++btl_openib_cpc_include = oob
++btl_openib_receive_queues = S,4096,1024:S,12288,512:S,65536,512
++
++## Enable cpu affinity
++opal_paffinity_alone = 1
++
++## Setup MPI options
++mpi_show_handle_leaks = 0
++mpi_warn_on_fork = 1
++mpi_abort_print_stack = 0
++

--- a/repo/v0.23/isamrepo/packages/openmpi/nolegacylaunchers.sh
+++ b/repo/v0.23/isamrepo/packages/openmpi/nolegacylaunchers.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+echo "This version of Spack (openmpi ~legacylaunchers schedulers=slurm) "
+echo "is installed without the mpiexec/mpirun commands to prevent "
+echo "unintended performance issues. See https://github.com/spack/spack/pull/10340 "
+echo "for more details."
+echo "If you understand the potential consequences of a misconfigured mpirun, you can"
+echo "use spack to install 'openmpi+legacylaunchers' to restore the executables."
+echo "Otherwise, use srun to launch your MPI executables."
+exit 2

--- a/repo/v0.23/isamrepo/packages/openmpi/opal_assembly_arch.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/opal_assembly_arch.patch
@@ -1,0 +1,27 @@
+diff --git a/opal/include/opal/sys/gcc_builtin/atomic.h b/opal/include/opal/sys/gcc_builtin/atomic.h
+index d85ff02bd6a..a465fdae5db 100644
+--- a/opal/include/opal/sys/gcc_builtin/atomic.h
++++ b/opal/include/opal/sys/gcc_builtin/atomic.h
+@@ -13,8 +13,8 @@
+  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+  * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
+  *                         reserved.
+- * Copyright (c) 2016-2017 Research Organization for Information Science
+- *                         and Technology (RIST). All rights reserved.
++ * Copyright (c) 2016-2021 Research Organization for Information Science
++ *                         and Technology (RIST).  All rights reserved.
+  * Copyright (c) 2018      Triad National Security, LLC. All rights
+  *                         reserved.
+  * $COPYRIGHT$
+@@ -61,9 +61,8 @@ static inline void opal_atomic_rmb(void)
+ {
+ #if OPAL_ASSEMBLY_ARCH == OPAL_X86_64
+     /* work around a bug in older gcc versions where ACQUIRE seems to get
+-     * treated as a no-op instead of being equivalent to
+-     * __asm__ __volatile__("": : :"memory") */
+-    __atomic_thread_fence (__ATOMIC_SEQ_CST);
++     * treated as a no-op instead */
++    __asm__ __volatile__("": : :"memory");
+ #else
+     __atomic_thread_fence (__ATOMIC_ACQUIRE);
+ #endif

--- a/repo/v0.23/isamrepo/packages/openmpi/package.py
+++ b/repo/v0.23/isamrepo/packages/openmpi/package.py
@@ -1,0 +1,1442 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import itertools
+import os
+import re
+import sys
+
+import llnl.util.tty as tty
+
+from spack.package import *
+
+
+class Openmpi(AutotoolsPackage, CudaPackage):
+    """An open source Message Passing Interface implementation.
+
+    The Open MPI Project is an open source Message Passing Interface
+    implementation that is developed and maintained by a consortium
+    of academic, research, and industry partners. Open MPI is
+    therefore able to combine the expertise, technologies, and
+    resources from all across the High Performance Computing
+    community in order to build the best MPI library available.
+    Open MPI offers advantages for system and software vendors,
+    application developers and computer science researchers.
+    """
+
+    homepage = "https://www.open-mpi.org"
+    url = "https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.0.tar.bz2"
+    list_url = "https://www.open-mpi.org/software/ompi/"
+    git = "https://github.com/open-mpi/ompi.git"
+
+    maintainers("hppritcha", "naughtont3")
+
+    executables = ["^ompi_info$"]
+
+    tags = ["e4s"]
+
+    license("custom")
+
+    version("main", branch="main", submodules=True)
+
+    # Current
+    version(
+        "5.0.5", sha256="6588d57c0a4bd299a24103f4e196051b29e8b55fbda49e11d5b3d32030a32776"
+    )  # libmpi.so.40.40.5
+
+    # Still supported
+    version(
+        "5.0.4", sha256="64526852cdd88b2d30e022087c16ab3e03806c451b10cd691d5c1ac887d8ef9d"
+    )  # libmpi.so.40.40.4
+    version(
+        "5.0.3", sha256="990582f206b3ab32e938aa31bbf07c639368e4405dca196fabe7f0f76eeda90b"
+    )  # libmpi.so.40.40.3
+    version(
+        "5.0.2", sha256="ee46ad8eeee2c3ff70772160bff877cbf38c330a0bc3b3ddc811648b3396698f"
+    )  # libmpi.so.40.40.2
+    version(
+        "5.0.1", sha256="e357043e65fd1b956a47d0dae6156a90cf0e378df759364936c1781f1a25ef80"
+    )  # libmpi.so.40.40.1
+    version(
+        "5.0.0", sha256="9d845ca94bc1aeb445f83d98d238cd08f6ec7ad0f73b0f79ec1668dbfdacd613"
+    )  # libmpi.so.40.40.0
+    version(
+        "4.1.8", sha256="466f68e3132a1dc02710cc2011fafced8336d98359fa2dae4dddcfd5719f12a9"
+    )  # libmpi.so.40.30.8
+    version(
+        "4.1.7", sha256="54a33cb7ad81ff0976f15a6cc8003c3922f0f3d8ceed14e1813ef3603f22cd34"
+    )  # libmpi.so.40.30.7
+    version(
+        "4.1.6", sha256="f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415"
+    )  # libmpi.so.40.30.6
+    version(
+        "4.1.5", sha256="a640986bc257389dd379886fdae6264c8cfa56bc98b71ce3ae3dfbd8ce61dbe3"
+    )  # libmpi.so.40.30.5
+    version(
+        "4.1.4", sha256="92912e175fd1234368c8730c03f4996fe5942e7479bb1d10059405e7f2b3930d"
+    )  # libmpi.so.40.30.4
+    version(
+        "4.1.3", sha256="3d81d04c54efb55d3871a465ffb098d8d72c1f48ff1cbaf2580eb058567c0a3b"
+    )  # libmpi.so.40.30.3
+    version(
+        "4.1.2", sha256="9b78c7cf7fc32131c5cf43dd2ab9740149d9d87cadb2e2189f02685749a6b527"
+    )  # libmpi.so.40.30.2
+    version(
+        "4.1.1", sha256="e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda"
+    )  # libmpi.so.40.30.1
+    version(
+        "4.1.0", sha256="73866fb77090819b6a8c85cb8539638d37d6877455825b74e289d647a39fd5b5"
+    )  # libmpi.so.40.30.0
+    version(
+        "4.0.7", sha256="7d3ecc8389161eb721982c855f89c25dca289001577a01a439ae97ce872be997"
+    )  # libmpi.so.40.20.7
+    version(
+        "4.0.6", sha256="94b7b59ae9860f3bd7b5f378a698713e7b957070fdff2c43453b6cbf8edb410c"
+    )  # libmpi.so.40.20.6
+    version(
+        "4.0.5", sha256="c58f3863b61d944231077f344fe6b4b8fbb83f3d1bc93ab74640bf3e5acac009"
+    )  # libmpi.so.40.20.5
+    version(
+        "4.0.4", sha256="47e24eb2223fe5d24438658958a313b6b7a55bb281563542e1afc9dec4a31ac4"
+    )  # libmpi.so.40.20.4
+    version(
+        "4.0.3", sha256="1402feced8c3847b3ab8252165b90f7d1fa28c23b6b2ca4632b6e4971267fd03"
+    )  # libmpi.so.40.20.3
+    version(
+        "4.0.2", sha256="900bf751be72eccf06de9d186f7b1c4b5c2fa9fa66458e53b77778dffdfe4057"
+    )  # libmpi.so.40.20.2
+    version(
+        "4.0.1", sha256="cce7b6d20522849301727f81282201d609553103ac0b09162cf28d102efb9709"
+    )  # libmpi.so.40.20.1
+    version(
+        "4.0.0", sha256="2f0b8a36cfeb7354b45dda3c5425ef8393c9b04115570b615213faaa3f97366b"
+    )  # libmpi.so.40.20.0
+
+    # Retired
+    version(
+        "3.1.6", sha256="50131d982ec2a516564d74d5616383178361c2f08fdd7d1202b80bdf66a0d279"
+    )  # libmpi.so.40.10.4
+    version(
+        "3.1.5", sha256="fbf0075b4579685eec8d56d34d4d9c963e6667825548554f5bf308610af72133"
+    )  # libmpi.so.40.10.4
+    version(
+        "3.1.4", sha256="17a69e0054db530c7dc119f75bd07d079efa147cf94bf27e590905864fe379d6"
+    )  # libmpi.so.40.10.4
+    version(
+        "3.1.3", sha256="8be04307c00f51401d3fb9d837321781ea7c79f2a5a4a2e5d4eaedc874087ab6"
+    )  # libmpi.so.40.10.3
+    version(
+        "3.1.2", sha256="c654ed847f34a278c52a15c98add40402b4a90f0c540779f1ae6c489af8a76c5"
+    )  # libmpi.so.40.10.2
+    version(
+        "3.1.1", sha256="3f11b648dd18a8b878d057e9777f2c43bf78297751ad77ae2cef6db0fe80c77c"
+    )  # libmpi.so.40.10.1
+    version(
+        "3.1.0", sha256="b25c044124cc859c0b4e6e825574f9439a51683af1950f6acda1951f5ccdf06c"
+    )  # libmpi.so.40.10.0
+    version(
+        "3.0.5", sha256="f8976b95f305efc435aa70f906b82d50e335e34cffdbf5d78118a507b1c6efe8"
+    )  # libmpi.so.40.00.5
+    version(
+        "3.0.4", sha256="2ff4db1d3e1860785295ab95b03a2c0f23420cda7c1ae845c419401508a3c7b5"
+    )  # libmpi.so.40.00.5
+    version(
+        "3.0.3", sha256="fb228e42893fe6a912841a94cd8a0c06c517701ae505b73072409218a12cf066"
+    )  # libmpi.so.40.00.4
+    version(
+        "3.0.2", sha256="d2eea2af48c1076c53cabac0a1f12272d7470729c4e1cb8b9c2ccd1985b2fb06"
+    )  # libmpi.so.40.00.2
+    version(
+        "3.0.1", sha256="663450d1ee7838b03644507e8a76edfb1fba23e601e9e0b5b2a738e54acd785d"
+    )  # libmpi.so.40.00.1
+    version(
+        "3.0.0", sha256="f699bff21db0125d8cccfe79518b77641cd83628725a1e1ed3e45633496a82d7"
+    )  # libmpi.so.40.00.0
+
+    version(
+        "2.1.6", sha256="98b8e1b8597bbec586a0da79fcd54a405388190247aa04d48e8c40944d4ca86e"
+    )  # libmpi.so.20.10.3
+    version(
+        "2.1.5", sha256="b807ccab801f27c3159a5edf29051cd3331d3792648919f9c4cee48e987e7794"
+    )  # libmpi.so.20.10.3
+    version(
+        "2.1.4", sha256="3e03695ca8bd663bc2d89eda343c92bb3d4fc79126b178f5ddcb68a8796b24e2"
+    )  # libmpi.so.20.10.3
+    version(
+        "2.1.3", sha256="285b3e2a69ed670415524474496043ecc61498f2c63feb48575f8469354d79e8"
+    )  # libmpi.so.20.10.2
+    version(
+        "2.1.2", sha256="3cc5804984c5329bdf88effc44f2971ed244a29b256e0011b8deda02178dd635"
+    )  # libmpi.so.20.10.2
+    version(
+        "2.1.1", sha256="bd7badd4ff3afa448c0d7f3ca0ee6ce003b957e9954aa87d8e4435759b5e4d16"
+    )  # libmpi.so.20.10.1
+    version(
+        "2.1.0", sha256="b169e15f5af81bf3572db764417670f508c0df37ce86ff50deb56bd3acb43957"
+    )  # libmpi.so.20.10.0
+
+    version(
+        "2.0.4", sha256="4f82d5f7f294becbd737319f74801206b08378188a95b70abe706fdc77a0c20b"
+    )  # libmpi.so.20.0.4
+    version(
+        "2.0.3", sha256="b52c0204c0e5954c9c57d383bb22b4181c09934f97783292927394d29f2a808a"
+    )  # libmpi.so.20.0.3
+    version(
+        "2.0.2", sha256="cae396e643f9f91f0a795f8d8694adf7bacfb16f967c22fb39e9e28d477730d3"
+    )  # libmpi.so.20.0.2
+    version(
+        "2.0.1", sha256="fed74f4ae619b7ebcc18150bb5bdb65e273e14a8c094e78a3fea0df59b9ff8ff"
+    )  # libmpi.so.20.0.1
+    version(
+        "2.0.0", sha256="08b64cf8e3e5f50a50b4e5655f2b83b54653787bd549b72607d9312be44c18e0"
+    )  # libmpi.so.20.0.0
+
+    # Ancient
+    version(
+        "1.10.7", sha256="a089ece151fec974905caa35b0a59039b227bdea4e7933069e94bee4ed0e5a90"
+    )  # libmpi.so.12.0.7
+    version(
+        "1.10.6", sha256="65606184a084a0eda6102b01e5a36a8f02d3195d15e91eabbb63e898bd110354"
+    )  # libmpi.so.12.0.6
+    version(
+        "1.10.5", sha256="a95fa355ed3a905c7c187bc452529a9578e2d6bae2559d8197544ab4227b759e"
+    )  # libmpi.so.12.0.5
+    version(
+        "1.10.4", sha256="fb3c0c4c77896185013b6091b306d29ba592eb40d8395533da5c8bc300d922db"
+    )  # libmpi.so.12.0.4
+    version(
+        "1.10.3", sha256="7484bb664312082fd12edc2445b42362089b53b17fb5fce12efd4fe452cc254d"
+    )  # libmpi.so.12.0.3
+    version(
+        "1.10.2", sha256="8846e7e69a203db8f50af90fa037f0ba47e3f32e4c9ccdae2db22898fd4d1f59"
+    )  # libmpi.so.12.0.2
+    version(
+        "1.10.1", sha256="7919ecde15962bab2e26d01d5f5f4ead6696bbcacb504b8560f2e3a152bfe492"
+    )  # libmpi.so.12.0.1
+    version(
+        "1.10.0", sha256="26b432ce8dcbad250a9787402f2c999ecb6c25695b00c9c6ee05a306c78b6490"
+    )  # libmpi.so.12.0.0
+
+    version(
+        "1.8.8", sha256="a28382d1e6a36f4073412dc00836ff2524e42b674da9caf6ca7377baad790b94"
+    )  # libmpi.so.1.6.3
+    version(
+        "1.8.7", sha256="da629e9bd820a379cfafe15f842ee9b628d7451856085ccc23ee75ab3e1b48c7"
+    )  # libmpi.so.1.6.2
+    version(
+        "1.8.6", sha256="b9fe3bdfb86bd42cc53448e17f11278531b989b05ff9513bc88ba1a523f14e87"
+    )  # libmpi.so.1.6.1
+    version(
+        "1.8.5", sha256="4cea06a9eddfa718b09b8240d934b14ca71670c2dc6e6251a585ce948a93fbc4"
+    )  # libmpi.so.1.6.0
+    version(
+        "1.8.4", sha256="23158d916e92c80e2924016b746a93913ba7fae9fff51bf68d5c2a0ae39a2f8a"
+    )  # libmpi.so.1.6.0
+    version(
+        "1.8.3", sha256="2ef02dab61febeb74714ff80d508c00b05defc635b391ed2c8dcc1791fbc88b3"
+    )  # libmpi.so.1.6.0
+    version(
+        "1.8.2", sha256="ab70770faf1bac15ef44301fe2186b02f857646545492dd7331404e364a7d131"
+    )  # libmpi.so.1.5.2
+    version(
+        "1.8.1", sha256="171427ebc007943265f33265ec32e15e786763952e2bfa2eac95e3e192c1e18f"
+    )  # libmpi.so.1.5.0
+    version(
+        "1.8", sha256="35d5db86f49c0c64573b2eaf6d51c94ed8a06a9bb23dda475e602288f05e4ecf"
+    )  # libmpi.so.1.5.0
+
+    version(
+        "1.7.5", sha256="cb3eef6880537d341d5d098511d390ec853716a6ec94007c03a0d1491b2ac8f2"
+    )  # libmpi.so.1.4.0
+    version(
+        "1.7.4", sha256="ff8e31046c5bacfc6202d67f2479731ccd8542cdd628583ae75874000975f45c"
+    )  # libmpi.so.1.3.0
+    version(
+        "1.7.3", sha256="438d96c178dbf5a1bc92fa1d238a8225d87b64af26ce2a07789faaf312117e45"
+    )  # libmpi.so.1.2.0
+    version(
+        "1.7.2", sha256="82a1c477dcadad2032ab24d9be9e39c1042865965841911f072c49aa3544fd85"
+    )  # libmpi.so.1.1.2
+    version(
+        "1.7.1", sha256="554583008fa34ecdfaca22e46917cc3457a69cba08c29ebbf53eef4f4b8be171"
+    )  # libmpi.so.1.1.1
+    version(
+        "1.7", sha256="542e44aaef6546798c0d39c0fd849e9fbcd04a762f0ab100638499643253a513"
+    )  # libmpi.so.1.1.0
+
+    version(
+        "1.6.5", sha256="fe37bab89b5ef234e0ac82dc798282c2ab08900bf564a1ec27239d3f1ad1fc85"
+    )  # libmpi.so.1.0.8
+    version(
+        "1.6.4", sha256="40cb113a27d76e1e915897661579f413564c032dc6e703073e6a03faba8093fa"
+    )  # libmpi.so.1.0.7
+    version(
+        "1.6.3", sha256="0c30cfec0e420870630fdc101ffd82f7eccc90276bc4e182f8282a2448668798"
+    )  # libmpi.so.1.0.6
+    version(
+        "1.6.2", sha256="5cc7744c6cc4ec2c04bc76c8b12717c4011822a2bd7236f2ea511f09579a714a"
+    )  # libmpi.so.1.0.3
+    version(
+        "1.6.1", sha256="077240dd1ab10f0caf26931e585db73848e9815c7119b993f91d269da5901e3a"
+    )  # libmpi.so.1.0.3
+    version(
+        "1.6", sha256="6e0d8b336543fb9ab78c97d364484923167857d30b266dfde1ccf60f356b9e0e"
+    )  # libmpi.so.1.0.3
+
+    version(
+        "1.5.5", sha256="660e6e49315185f88a87b6eae3d292b81774eab7b29a9b058b10eb35d892ff23"
+    )  # libmpi.so.1.0.3
+    version(
+        "1.5.4", sha256="81126a95a51b8af4bb0ad28790f852c30d22d989713ec30ad22e9e0a79587ef6"
+    )  # libmpi.so.1.0.2
+    version(
+        "1.5.3", sha256="70745806cdbe9b945d47d9fa058f99e072328e41e40c0ced6dd75220885c5263"
+    )  # libmpi.so.1.0.1
+    version(
+        "1.5.2", sha256="7123b781a9fd21cc79870e7fe01e9c0d3f36935c444922661e24af523b116ab1"
+    )  # libmpi.so.1.0.1
+    version(
+        "1.5.1", sha256="c28bb0bd367ceeec08f739d815988fca54fc4818762e6abcaa6cfedd6fd52274"
+    )  # libmpi.so.1.0.0
+    version(
+        "1.5", sha256="1882b1414a94917ec26b3733bf59da6b6db82bf65b5affd7f0fcbd96efaca506"
+    )  # libmpi.so.1.0.0
+
+    version(
+        "1.4.5", sha256="a3857bc69b7d5258cf7fc1ed1581d9ac69110f5c17976b949cb7ec789aae462d"
+    )  # libmpi.so.0.0.4
+    version(
+        "1.4.4", sha256="9ad125304a89232d5b04da251f463fdbd8dcd997450084ba4227e7f7a095c3ed"
+    )  # libmpi.so.0.0.3
+    version(
+        "1.4.3", sha256="220b72b1c7ee35469ff74b4cfdbec457158ac6894635143a33e9178aa3981015"
+    )  # libmpi.so.0.0.2
+    version(
+        "1.4.2", sha256="19129e3d51860ad0a7497ede11563908ba99c76b3a51a4d0b8801f7e2db6cd80"
+    )  # libmpi.so.0.0.2
+    version(
+        "1.4.1", sha256="d4d71d7c670d710d2d283ea60af50d6c315318a4c35ec576bedfd0f3b7b8c218"
+    )  # libmpi.so.0.0.1
+    version(
+        "1.4", sha256="fa55edef1bd8af256e459d4d9782516c6998b9d4698eda097d5df33ae499858e"
+    )  # libmpi.so.0.0.1
+
+    version(
+        "1.3.4", sha256="fbfe4b99b0c98f81a4d871d02f874f84ea66efcbb098f6ad84ebd19353b681fc"
+    )  # libmpi.so.0.0.1
+    version(
+        "1.3.3", sha256="e1425853282da9237f5b41330207e54da1dc803a2e19a93dacc3eca1d083e422"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.3.2", sha256="c93ed90962d879a2923bed17171ed9217036ee1279ffab0925ea7eead26105d8"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.3.1", sha256="22d18919ddc5f49d55d7d63e2abfcdac34aa0234427e861e296a630c6c11632c"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.3", sha256="864706d88d28b586a045461a828962c108f5912671071bc3ef0ca187f115e47b"
+    )  # libmpi.so.0.0.0
+
+    version(
+        "1.2.9", sha256="0eb36abe09ba7bf6f7a70255974e5d0a273f7f32d0e23419862c6dcc986f1dff"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2.8", sha256="75b286cb3b1bf6528a7e64ee019369e0601b8acb5c3c167a987f755d1e41c95c"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2.7", sha256="d66c7f0bb11494023451651d0e61afaef9d2199ed9a91ed08f0dedeb51541c36"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2.6", sha256="e5b27af5a153a257b1562a97bbf7164629161033934558cefd8e1e644a9f73d3"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2.5", sha256="3c3aed872c17165131c77bd7a12fe8aec776cb23da946b7d12840db93ab79322"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2.4", sha256="594a3a0af69cc7895e0d8f9add776a44bf9ed389794323d0b1b45e181a97e538"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2.3", sha256="f936ca3a197e5b2d1a233b7d546adf07898127683b03c4b37cf31ae22a6f69bb"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2.2", sha256="aa763e0e6a6f5fdff8f9d3fc988a4ba0ed902132d292c85aef392cc65bb524e6"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2.1", sha256="a94731d84fb998df33960e0b57ea5661d35e7c7cd9d03d900f0b6a5a72e4546c"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.2", sha256="ba0bfa3dec2ead38a3ed682ca36a0448617b8e29191ab3f48c9d0d24d87d14c0"
+    )  # libmpi.so.0.0.0
+
+    version(
+        "1.1.5", sha256="913deaedf3498bd5d06299238ec4d048eb7af9c3afd8e32c12f4257c8b698a91"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.1.4", sha256="21c37f85df7e959f17cc7cb5571d8db2a94ed2763e3e96e5d052aff2725c1d18"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.1.3", sha256="c33f8f5e65cfe872173616cca27ae8dc6d93ea66e0708118b9229128aecc174f"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.1.2", sha256="3bd8d9fe40b356be7f9c3d336013d3865f8ca6a79b3c6e7ef28784f6c3a2b8e6"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.1.1", sha256="dc31aaec986c4ce436dbf31e73275ed1a9391432dcad7609de8d0d3a78d2c700"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.1", sha256="ebe14801d2caeeaf47b0e437b43f73668b711f4d3fcff50a0d665d4bd4ea9531"
+    )  # libmpi.so.0.0.0
+
+    version(
+        "1.0.2", sha256="ccd1074d7dd9566b73812d9882c84e446a8f4c77b6f471d386d3e3b9467767b8"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.0.1", sha256="f801b7c8ea6c485ac0709a628a479aeafa718a205ed6bc0cf2c684bc0cc73253"
+    )  # libmpi.so.0.0.0
+    version(
+        "1.0", sha256="cf75e56852caebe90231d295806ac3441f37dc6d9ad17b1381791ebb78e21564"
+    )  # libmpi.so.0.0.0
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    patch("ad_lustre_rwcontig_open_source.patch", when="@1.6.5")
+    patch("llnl-platforms.patch", when="@1.6.5")
+    patch("configure.patch", when="@1.10.1")
+    patch("fix_multidef_pmi_class.patch", when="@2.0.0:2.0.1")
+    patch("fix-ucx-1.7.0-api-instability.patch", when="@4.0.0:4.0.2")
+
+    # Vader Bug: https://github.com/open-mpi/ompi/issues/5375
+    # Haven't release fix for 2.1.x
+    patch("btl_vader.patch", when="@2.1.3:2.1.5")
+
+    # Fixed in 3.0.3 and 3.1.3
+    patch("btl_vader.patch", when="@3.0.1:3.0.2")
+    patch("btl_vader.patch", when="@3.1.0:3.1.2")
+
+    # Fix MPI_Sizeof() in the "mpi" Fortran module for compilers that do not
+    # support "IGNORE TKR" functionality (e.g. NAG).
+    # The issue has been resolved upstream in two steps:
+    #   1) https://github.com/open-mpi/ompi/pull/2294
+    #   2) https://github.com/open-mpi/ompi/pull/5099
+    # The first one was applied starting version v3.0.0 and backported to
+    # v1.10. A subset with relevant modifications is applicable starting
+    # version 1.8.4.
+    patch("use_mpi_tkr_sizeof/step_1.patch", when="@1.8.4:1.10.6,2.0:2")
+    # The second patch was applied starting version v4.0.0 and backported to
+    # v2.x, v3.0.x, and v3.1.x.
+    patch("use_mpi_tkr_sizeof/step_2.patch", when="@1.8.4:2.1.3,3:3.0.1")
+    # To fix performance regressions introduced while fixing a bug in older
+    # gcc versions on x86_64, Refs. open-mpi/ompi#8603
+    patch("opal_assembly_arch.patch", when="@4.0.0:4.0.5,4.1.0")
+    # Fix reduce operations for unsigned long integers
+    # See https://github.com/open-mpi/ompi/issues/10648
+    patch(
+        "https://github.com/open-mpi/ompi/commit/8e6d9ba8058a0c128438dbc0cd6476f1abb1d4f1.patch?full_index=1",
+        sha256="12f3aabbcdb02f28138e250273c2f62591db4b1f9f8aa3dcc3ef9ed551f4f587",
+        when="@4.0.7,4.1.2:4.1.4",
+    )
+    # To fix an error in Open MPI configury related to findng dl lib.
+    # This is specific to the 5.0.0 release.
+    patch("fix-for-dlopen-missing-symbol-problem.patch", when="@5.0.0")
+    # Patches to accelerator CUDA component to link in libcuda
+    # when in non-standard location
+    patch("accelerator-cuda-fix-bug-in-makefile.patch", when="@5.0.0")
+    patch("btlsmcuda-fix-problem-with-makefile.patch", when="@5.0.0")
+    patch("accelerator-build-components-as-dso-s-by-default.patch", when="@5.0.0:5.0.1")
+
+    # OpenMPI 5.0.0-5.0.3 needs to change PMIX version check to compile w/ PMIX > 4.2.5
+    # https://github.com/open-mpi/ompi/issues/12537#issuecomment-2103350910
+    # https://github.com/openpmix/prrte/pull/1957
+    patch("pmix_getline_pmix_version.patch", when="@5.0.0:5.0.3")
+    patch("pmix_getline_pmix_version-prte.patch", when="@5.0.3")
+
+    FABRICS = (
+        "psm",
+        "psm2",
+        "verbs",
+        "mxm",
+        "ucx",
+        "ofi",
+        "fca",
+        "hcoll",
+        "ucc",
+        "xpmem",
+        "cma",
+        "knem",
+    )
+
+    variant(
+        "fabrics",
+        values=disjoint_sets(
+            ("auto",), FABRICS  # shared memory transports
+        ).with_non_feature_values("auto", "none"),
+        description="List of fabrics that are enabled; " "'auto' lets openmpi determine",
+    )
+
+    SCHEDULERS = ("alps", "lsf", "tm", "slurm", "sge", "loadleveler")
+
+    variant(
+        "schedulers",
+        values=disjoint_sets(("auto",), SCHEDULERS).with_non_feature_values("auto", "none"),
+        description="List of schedulers for which support is enabled; "
+        "'auto' lets openmpi determine",
+    )
+
+    # Additional support options
+    variant("atomics", default=True, description="Enable built-in atomics")
+    variant("java", default=False, when="@1.7.4:", description="Build Java support")
+    variant("static", default=False, description="Build static libraries")
+    variant("sqlite3", default=False, when="@1.7.3:1", description="Build SQLite3 support")
+    variant("vt", default=True, description="Build VampirTrace support")
+    variant(
+        "thread_multiple",
+        default=False,
+        when="@1.5.4:2",
+        description="Enable MPI_THREAD_MULTIPLE support",
+    )
+    variant(
+        "pmi", default=False, when="@1.5.5:4 schedulers=slurm", description="Enable PMI support"
+    )
+    variant(
+        "wrapper-rpath",
+        default=True,
+        when="@1.7.4:",
+        description="Enable rpath support in the wrappers",
+    )
+    variant("cxx", default=False, when="@:4", description="Enable deprecated C++ MPI bindings")
+    variant(
+        "cxx_exceptions",
+        default=False,
+        when="@:4",
+        description="Enable deprecated C++ exception support",
+    )
+    variant("gpfs", default=False, description="Enable GPFS support")
+    variant(
+        "singularity",
+        default=False,
+        when="@:4",
+        description="Build deprecated support for the Singularity container",
+    )
+    variant("lustre", default=False, description="Lustre filesystem library support")
+    variant("romio", default=True, when="@:5", description="Enable ROMIO support")
+    variant("romio", default=False, when="@5:", description="Enable ROMIO support")
+    variant(
+        "romio-filesystem",
+        description="Add the filesystem to romio",
+        values=disjoint_sets(
+            (
+                "daos",
+                "nfs",
+                "ufs",
+                "pvfs2",
+                "testfs",
+                "xfs",
+                "panfs",
+                "lustre",
+                "gpfs",
+                "ime",
+                "quobytefs",
+            )
+        ).with_non_feature_values("none"),
+    )
+
+    variant("rsh", default=True, description="Enable rsh (openssh) process lifecycle management")
+    variant(
+        "orterunprefix",
+        default=False,
+        when="@1.3:4",
+        description="Prefix Open MPI to PATH and LD_LIBRARY_PATH on local and remote hosts",
+    )
+    # Adding support to build a debug version of OpenMPI that activates
+    # Memchecker, as described here:
+    #
+    # https://www.open-mpi.org/faq/?category=debugging#memchecker_what
+    #
+    # This option degrades run-time support, and thus is disabled by default
+    variant(
+        "memchecker",
+        default=False,
+        description="Memchecker support for debugging [degrades performance]",
+        sticky=True,
+    )
+
+    variant(
+        "legacylaunchers",
+        default=False,
+        when="@1.6:4 schedulers=slurm",
+        description="Do not remove mpirun/mpiexec when building with slurm",
+    )
+    # Variants to use internal packages
+    variant("internal-hwloc", default=False, description="Use internal hwloc")
+    variant("internal-pmix", default=False, description="Use internal pmix")
+    variant("internal-libevent", default=False, description="Use internal libevent")
+    variant("openshmem", default=False, description="Enable building OpenSHMEM")
+    variant("debug", default=False, description="Make debug build", when="build_system=autotools")
+
+    variant(
+        "two_level_namespace",
+        default=False,
+        description="""Build shared libraries and programs
+built with the mpicc/mpifort/etc. compiler wrappers
+with '-Wl,-commons,use_dylibs' and without
+'-Wl,-flat_namespace'.""",
+    )
+
+    # Patch to allow two-level namespace on a MacOS platform when building
+    # openmpi. Unfortuntately, the openmpi configure command has flat namespace
+    # hardwired in. In spack, this only works for openmpi up to versions 4,
+    # because for versions 5+ autoreconf is triggered (see below) and this
+    # patch needs to be applied (again) AFTER autoreconf ran.
+    @when("+two_level_namespace platform=darwin")
+    def patch(self):
+        filter_file(r"-flat_namespace", "-commons,use_dylibs", "configure")
+
+    provides("mpi@:2.0", when="@:1.2")
+    provides("mpi@:2.1", when="@1.3:1.7.2")
+    provides("mpi@:2.2", when="@1.7.3:1.7.4")
+    provides("mpi@:3.0", when="@1.7.5:1.10.7")
+    provides("mpi@:3.1", when="@2.0.0:")
+
+    if sys.platform != "darwin":
+        depends_on("numactl")
+
+    depends_on("autoconf @2.69:", type="build", when="@5.0.0:,main")
+    depends_on("automake @1.13.4:", type="build", when="@5.0.0:,main")
+    depends_on("libtool @2.4.2:", type="build", when="@5.0.0:,main")
+
+    depends_on("perl", type="build")
+    depends_on("pkgconfig", type="build")
+
+    depends_on("hwloc@2:", when="@4: ~internal-hwloc")
+    # ompi@:3.0.0 doesn't support newer hwloc releases:
+    # "configure: error: OMPI does not currently support hwloc v2 API"
+    # Future ompi releases may support it, needs to be verified.
+    # See #7483 for context.
+    depends_on("hwloc@:1", when="@:3 ~internal-hwloc")
+
+    depends_on("hwloc +cuda", when="+cuda ~internal-hwloc")
+    depends_on("java", when="+java")
+    depends_on("sqlite", when="+sqlite3")
+    depends_on("zlib-api", when="@3:")
+    depends_on("valgrind~mpi", when="+memchecker")
+    # Singularity release 3 works better
+    depends_on("singularity@3:", when="+singularity")
+    depends_on("lustre", when="+lustre")
+
+    depends_on("opa-psm2", when="fabrics=psm2")
+    depends_on("rdma-core", when="fabrics=verbs")
+    depends_on("mxm", when="fabrics=mxm")
+    depends_on("binutils+libiberty", when="fabrics=mxm")
+    with when("fabrics=ucx"):
+        depends_on("ucx")
+        depends_on("ucx +thread_multiple", when="+thread_multiple")
+        depends_on("ucx +thread_multiple", when="@3.0.0:")
+        depends_on("ucx@1.9.0:", when="@4.0.6:4.0")
+        depends_on("ucx@1.9.0:", when="@4.1.1:4.1")
+        depends_on("ucx@1.9.0:", when="@5.0.0:")
+    depends_on("libfabric", when="fabrics=ofi")
+    depends_on("fca", when="fabrics=fca")
+    depends_on("hcoll", when="fabrics=hcoll")
+    depends_on("ucc", when="fabrics=ucc")
+    depends_on("xpmem", when="fabrics=xpmem")
+    depends_on("knem", when="fabrics=knem")
+
+    depends_on("lsf", when="schedulers=lsf")
+    depends_on("pbs", when="schedulers=tm")
+    depends_on("slurm", when="schedulers=slurm")
+
+    # PMIx is unavailable for @1, and required for @2:
+    # OpenMPI @2: includes a vendored version:
+    with when("~internal-pmix"):
+        depends_on("pmix@1", when="@2")
+        depends_on("pmix@3.2:", when="@4:")
+        depends_on("pmix@4.2.4:", when="@5:")
+
+        # pmix@4.2.3 contains a breaking change, compat fixed in openmpi@4.1.6
+        # See https://www.mail-archive.com/announce@lists.open-mpi.org//msg00158.html
+        depends_on("pmix@:4.2.2", when="@:4.1.5")
+
+    # Libevent is required when *vendored* PMIx is used
+    depends_on("libevent@2:", when="~internal-libevent")
+
+    depends_on("openssh", type="run", when="+rsh")
+
+    depends_on("cuda", type=("build", "link", "run"), when="@5: +cuda")
+
+    conflicts("+cxx_exceptions", when="%nvhpc", msg="nvc does not ignore -fexceptions, but errors")
+
+    # CUDA support was added in 1.7, and since the variant is part of the
+    # parent package we must express as a conflict rather than a conditional
+    # variant.
+    conflicts("+cuda", when="@:1.6")
+    # PSM2 support was added in 1.10.0
+    conflicts("fabrics=psm2", when="@:1.8")
+    # MXM support was added in 1.5.4
+    conflicts("fabrics=mxm", when="@:1.5.3")
+    # libfabric (OFI) support was added in 1.10.0
+    conflicts("fabrics=ofi", when="@:1.8")
+    # fca support was added in 1.5.0 and removed in 5.0.0
+    conflicts("fabrics=fca", when="@:1.4,5:")
+    # hcoll support was added in 1.7.3:
+    conflicts("fabrics=hcoll", when="@:1.7.2")
+    # ucc support was added in 4.1.4:
+    conflicts("fabrics=ucc", when="@:4.1.3")
+    # xpmem support was added in 1.7
+    conflicts("fabrics=xpmem", when="@:1.6")
+    # cma support was added in 1.7
+    conflicts("fabrics=cma", when="@:1.6")
+    # knem support was added in 1.5
+    conflicts("fabrics=knem", when="@:1.4")
+
+    conflicts(
+        "schedulers=loadleveler",
+        when="@3:",
+        msg="The loadleveler scheduler is not supported with " "openmpi(>=3).",
+    )
+
+    # According to this comment on github:
+    #
+    # https://github.com/open-mpi/ompi/issues/4338#issuecomment-383982008
+    #
+    # adding --enable-static silently disables slurm support via pmi/pmi2
+    # for versions older than 3.0.3,3.1.3,4.0.0
+    # Presumably future versions after 11/2018 should support slurm+static
+    conflicts("+static", when="schedulers=slurm @:3.0.2,3.1:3.1.2,4.0.0")
+
+    filter_compiler_wrappers("openmpi/*-wrapper-data*", relative_root="share")
+
+    extra_install_tests = "examples"
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)(output=str, error=str)
+        match = re.search(r"Open MPI: (\S+)", output)
+        return Version(match.group(1)) if match else None
+
+    @classmethod
+    def determine_variants(cls, exes, version):
+        results = []
+        for exe in exes:
+            variants = []
+            output = Executable(exe)("-a", output=str, error=str)
+            # Some of these options we have to find by hoping the
+            # configure string is in the ompi_info output. While this
+            # is usually true, it's not guaranteed.  For anything that
+            # begins with --, we want to use the defaults as provided
+            # by the openmpi package in the absense of any other info.
+
+            # atomics
+            if re.search(r"--enable-builtin-atomics", output):
+                variants.append("+atomics")
+
+            # java
+            if version in spack.version.ver("1.7.4:"):
+                match = re.search(r"\bJava bindings: (\S+)", output)
+                if match and is_enabled(match.group(1)):
+                    variants.append("+java")
+                else:
+                    variants.append("~java")
+
+            # static
+            if re.search(r"--enable-static", output):
+                variants.append("+static")
+            elif re.search(r"--disable-static", output):
+                variants.append("~static")
+            elif re.search(r"\bMCA (?:coll|oca|pml): monitoring", output):
+                # Built multiple variants of openmpi and ran diff.
+                # This seems to be the distinguishing feature.
+                variants.append("~static")
+
+            # sqlite
+            if version in spack.version.ver("1.7.3:1"):
+                if re.search(r"\bMCA db: sqlite", output):
+                    variants.append("+sqlite3")
+                else:
+                    variants.append("~sqlite3")
+
+            # vt
+            if re.search(r"--enable-contrib-no-build=vt", output):
+                variants.append("+vt")
+
+            # thread_multiple
+            if version in spack.version.ver("1.5.4:2"):
+                match = re.search(r"MPI_THREAD_MULTIPLE: (\S+?),?", output)
+                if match and is_enabled(match.group(1)):
+                    variants.append("+thread_multiple")
+                else:
+                    variants.append("~thread_multiple")
+
+            # cuda
+            match = re.search(
+                r'parameter "mpi_built_with_cuda_support" ' + r'\(current value: "(\S+)"', output
+            )
+            if match and is_enabled(match.group(1)):
+                variants.append("+cuda")
+            else:
+                variants.append("~cuda")
+
+            # wrapper-rpath
+            if version in spack.version.ver("1.7.4:"):
+                match = re.search(r"\bWrapper compiler rpath: (\S+)", output)
+                if match and is_enabled(match.group(1)):
+                    variants.append("+wrapper-rpath")
+                else:
+                    variants.append("~wrapper-rpath")
+
+            # cxx
+            if version in spack.version.ver(":4"):
+                match = re.search(r"\bC\+\+ bindings: (\S+)", output)
+                if match and match.group(1) == "yes":
+                    variants.append("+cxx")
+                else:
+                    variants.append("~cxx")
+
+            # cxx_exceptions
+            if version in spack.version.ver(":4"):
+                match = re.search(r"\bC\+\+ exceptions: (\S+)", output)
+                if match and match.group(1) == "yes":
+                    variants.append("+cxx_exceptions")
+                else:
+                    variants.append("~cxx_exceptions")
+
+            # singularity
+            if version in spack.version.ver(":4"):
+                if re.search(r"--with-singularity", output):
+                    variants.append("+singularity")
+
+            # lustre
+            if re.search(r"--with-lustre", output):
+                variants.append("+lustre")
+
+            # memchecker
+            match = re.search(r"Memory debugging support: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+memchecker")
+            else:
+                variants.append("~memchecker")
+
+            # pmi
+            if version in spack.version.ver("1.5.5:4"):
+                if re.search(r"\bMCA (?:ess|prrte): pmi", output):
+                    variants.append("+pmi")
+                else:
+                    variants.append("~pmi")
+
+            # fabrics
+            used_fabrics = []
+            for fabric in cls.FABRICS:
+                match = re.search(r"\bMCA (?:mtl|btl|pml): %s\b" % fabric, output)
+                if match:
+                    used_fabrics.append(fabric)
+            if used_fabrics:
+                variants.append("fabrics=" + ",".join(used_fabrics))
+            else:
+                variants.append("fabrics=none")
+
+            # schedulers
+            used_schedulers = []
+            for scheduler in cls.SCHEDULERS:
+                match = re.search(r"\bMCA (?:prrte|ras): %s\b" % scheduler, output)
+                if match:
+                    used_schedulers.append(scheduler)
+            if used_schedulers:
+                variants.append("schedulers=" + ",".join(used_schedulers))
+            else:
+                variants.append("schedulers=none")
+
+            # Get the appropriate compiler
+            match = re.search(r"\bC compiler absolute: (\S+)", output)
+            if match:
+                compiler = match.group(1)
+                compiler_spec = get_spack_compiler_spec(compiler)
+                if compiler_spec:
+                    variants.append("%" + str(compiler_spec))
+            results.append(" ".join(variants))
+        return results
+
+    def url_for_version(self, version):
+        url = "https://download.open-mpi.org/release/open-mpi/v{0}/openmpi-{1}.tar.bz2"
+        return url.format(version.up_to(2), version)
+
+    @property
+    def headers(self):
+        hdrs = HeaderList(find(self.prefix.include, "mpi.h", recursive=False))
+        if not hdrs:
+            hdrs = HeaderList(find(self.prefix, "mpi.h", recursive=True))
+        return hdrs or None
+
+    @property
+    def libs(self):
+        query_parameters = self.spec.last_query.extra_parameters
+        libraries = ["libmpi"]
+
+        if "cxx" in query_parameters:
+            libraries = ["libmpi_cxx"] + libraries
+
+        return find_libraries(libraries, root=self.prefix, shared=True, recursive=True)
+
+    def setup_run_environment(self, env):
+        # Because MPI is both a runtime and a compiler, we have to setup the
+        # compiler components as part of the run environment.
+        env.set("MPICC", join_path(self.prefix.bin, "mpicc"))
+        env.set("MPICXX", join_path(self.prefix.bin, "mpic++"))
+        env.set("MPIF77", join_path(self.prefix.bin, "mpif77"))
+        env.set("MPIF90", join_path(self.prefix.bin, "mpif90"))
+        # Open MPI also has had mpifort since v1.7, so we can set MPIFC to that
+        # Note: that mpif77 and mpif90 are deprecated since v1.7, but careful
+        # testing would be needed to change the MPIF77 and MPIF90 above. For now
+        # we just *add* functionality
+        if self.spec.satisfies("@1.7:"):
+            env.set("MPIFC", join_path(self.prefix.bin, "mpifort"))
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # Use the spack compiler wrappers under MPI
+        dependent_module = dependent_spec.package.module
+        env.set("OMPI_CC", dependent_module.spack_cc)
+        env.set("OMPI_CXX", dependent_module.spack_cxx)
+        env.set("OMPI_FC", dependent_module.spack_fc)
+        env.set("OMPI_F77", dependent_module.spack_f77)
+
+        # See https://www.open-mpi.org/faq/?category=building#installdirs
+        for suffix in [
+            "PREFIX",
+            "EXEC_PREFIX",
+            "BINDIR",
+            "SBINDIR",
+            "LIBEXECDIR",
+            "DATAROOTDIR",
+            "DATADIR",
+            "SYSCONFDIR",
+            "SHAREDSTATEDIR",
+            "LOCALSTATEDIR",
+            "LIBDIR",
+            "INCLUDEDIR",
+            "INFODIR",
+            "MANDIR",
+            "PKGDATADIR",
+            "PKGLIBDIR",
+            "PKGINCLUDEDIR",
+        ]:
+            env.unset(f"OPAL_{suffix}")
+
+    def setup_dependent_package(self, module, dependent_spec):
+        self.spec.mpicc = join_path(self.prefix.bin, "mpicc")
+        self.spec.mpicxx = join_path(self.prefix.bin, "mpic++")
+        self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
+        self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
+        self.spec.mpicxx_shared_libs = [
+            join_path(self.prefix.lib, "libmpi_cxx.{0}".format(dso_suffix)),
+            join_path(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
+        ]
+
+    # Most of the following with_or_without methods might seem redundant
+    # because Spack compiler wrapper adds the required -I and -L flags, which
+    # is enough for the configure script to find them. However, we also need
+    # the flags in Libtool (lib/*.la) and pkg-config (lib/pkgconfig/*.pc).
+    # Therefore, we pass the prefixes explicitly.
+
+    def with_or_without_psm2(self, activated):
+        if not activated:
+            return "--without-psm2"
+        return "--with-psm2={0}".format(self.spec["opa-psm2"].prefix)
+
+    def with_or_without_verbs(self, activated):
+        # Up through version 1.6, this option was named --with-openib.
+        # In version 1.7, it was renamed to be --with-verbs.
+        opt = "verbs" if self.spec.satisfies("@1.7:") else "openib"
+        if not activated:
+            return "--without-{0}".format(opt)
+        return "--with-{0}={1}".format(opt, self.spec["rdma-core"].prefix)
+
+    def with_or_without_mxm(self, activated):
+        if not activated:
+            return "--without-mxm"
+        return "--with-mxm={0}".format(self.spec["mxm"].prefix)
+
+    def with_or_without_ucx(self, activated):
+        if not activated:
+            return "--without-ucx"
+        return "--with-ucx={0}".format(self.spec["ucx"].prefix)
+
+    def with_or_without_ofi(self, activated):
+        # Up through version 3.0.3 this option was name --with-libfabric.
+        # In version 3.0.4, the old name was deprecated in favor of --with-ofi.
+        opt = "ofi" if self.spec.satisfies("@3.0.4:") else "libfabric"
+        if not activated:
+            return "--without-{0}".format(opt)
+        return "--with-{0}={1}".format(opt, self.spec["libfabric"].prefix)
+
+    def with_or_without_fca(self, activated):
+        if not activated:
+            return "--without-fca"
+        return "--with-fca={0}".format(self.spec["fca"].prefix)
+
+    def with_or_without_hcoll(self, activated):
+        if not activated:
+            return "--without-hcoll"
+        return "--with-hcoll={0}".format(self.spec["hcoll"].prefix)
+
+    def with_or_without_ucc(self, activated):
+        if not activated:
+            return "--without-ucc"
+        return "--with-ucc={0}".format(self.spec["ucc"].prefix)
+
+    def with_or_without_xpmem(self, activated):
+        if not activated:
+            return "--without-xpmem"
+        return "--with-xpmem={0}".format(self.spec["xpmem"].prefix)
+
+    def with_or_without_knem(self, activated):
+        if not activated:
+            return "--without-knem"
+        return "--with-knem={0}".format(self.spec["knem"].prefix)
+
+    def with_or_without_lsf(self, activated):
+        if not activated:
+            return "--without-lsf"
+        return "--with-lsf={0}".format(self.spec["lsf"].prefix)
+
+    def with_or_without_tm(self, activated):
+        if not activated:
+            return "--without-tm"
+        return "--with-tm={0}".format(self.spec["pbs"].prefix)
+
+    @run_before("autoreconf")
+    def die_without_fortran(self):
+        # Until we can pass variants such as +fortran through virtual
+        # dependencies depends_on('mpi'), require Fortran compiler to
+        # avoid delayed build errors in dependents.
+        if (self.compiler.f77 is None) and (self.compiler.fc is None):
+            raise InstallError("OpenMPI requires both C and Fortran compilers!")
+
+    @when("@main")
+    def autoreconf(self, spec, prefix):
+        perl = which("perl")
+        perl("autogen.pl")
+        if spec.satisfies("+two_level_namespace platform=darwin"):
+            filter_file(r"-flat_namespace", "-commons,use_dylibs", "configure")
+
+    @when("@5.0.0:5.0.1")
+    def autoreconf(self, spec, prefix):
+        perl = which("perl")
+        perl("autogen.pl", "--force")
+        if spec.satisfies("+two_level_namespace platform=darwin"):
+            filter_file(r"-flat_namespace", "-commons,use_dylibs", "configure")
+
+    def configure_args(self):
+        spec = self.spec
+        config_args = ["--enable-shared", "--disable-silent-rules", "--disable-sphinx"]
+
+        # Work around incompatibility with new apple-clang linker
+        # https://github.com/open-mpi/ompi/issues/12427
+        if spec.satisfies("@:4.1.6,5.0.0:5.0.3 %apple-clang@15:"):
+            config_args.append("--with-wrapper-fcflags=-Wl,-ld_classic")
+
+        # All rpath flags should be appended with self.compiler.cc_rpath_arg.
+        # Later, we might need to update share/openmpi/mpic++-wrapper-data.txt
+        # and mpifort-wrapper-data.txt (see filter_rpaths()).
+        wrapper_ldflags = []
+
+        config_args.extend(self.enable_or_disable("builtin-atomics", variant="atomics"))
+
+        if spec.satisfies("+pmi"):
+            config_args.append("--with-pmi={0}".format(spec["slurm"].prefix))
+        else:
+            config_args.extend(self.with_or_without("pmi"))
+
+        config_args.extend(self.enable_or_disable("static"))
+
+        if spec.satisfies("@4.0.0:4.0.2"):
+            # uct btl doesn't work with some UCX versions so just disable
+            config_args.append("--enable-mca-no-build=btl-uct")
+
+        # Remove ssh/rsh pml
+        if spec.satisfies("~rsh"):
+            config_args.append("--enable-mca-no-build=plm-rsh")
+
+        # Useful for ssh-based environments
+        # For v4 and lower
+        if spec.satisfies("+orterunprefix"):
+            config_args.append("--enable-orterun-prefix-by-default")
+
+        # some scientific packages ignore deprecated/remove symbols. Re-enable
+        # them for now, for discussion see
+        # https://github.com/open-mpi/ompi/issues/6114#issuecomment-446279495
+        if spec.satisfies("@4.0.1:"):
+            config_args.append("--enable-mpi1-compatibility")
+
+        # Fabrics
+        if "fabrics=auto" not in spec:
+            config_args.extend(self.with_or_without("fabrics"))
+
+        if spec.satisfies("@2.0.0:"):
+            if "fabrics=xpmem" in spec:
+                config_args.append("--with-cray-xpmem")
+            else:
+                config_args.append("--without-cray-xpmem")
+
+        # Schedulers
+        if "schedulers=auto" not in spec:
+            config_args.extend(self.with_or_without("schedulers"))
+
+        if spec.satisfies("schedulers=lsf"):
+            config_args.append("--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0]))
+
+        config_args.extend(self.enable_or_disable("memchecker"))
+        if spec.satisfies("+memchecker"):
+            config_args.extend(["--enable-debug"])
+
+        # Package dependencies
+        for dep in ["libevent", "lustre", "singularity", "valgrind"]:
+            if "^" + dep in spec:
+                config_args.append("--with-{0}={1}".format(dep, spec[dep].prefix))
+
+        # PMIx support
+        if spec.satisfies("+internal-pmix"):
+            config_args.append("--with-pmix=internal")
+        elif "^pmix" in spec:
+            config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
+
+        if "^zlib-api" in spec:
+            config_args.append("--with-zlib={0}".format(spec["zlib-api"].prefix))
+
+        # Hwloc support
+        if spec.satisfies("+internal-hwloc"):
+            config_args.append("--with-hwloc=internal")
+        elif "^hwloc" in spec:
+            config_args.append("--with-hwloc=" + spec["hwloc"].prefix)
+
+        # Java support
+        if "+java" in spec:
+            config_args.extend(
+                ["--enable-java", "--enable-mpi-java", "--with-jdk-dir=" + spec["java"].home]
+            )
+        elif spec.satisfies("@1.7.4:"):
+            config_args.extend(["--disable-java", "--disable-mpi-java"])
+
+        # Romio
+        if "~romio" in spec:
+            config_args.append("--disable-io-romio")
+
+        if not spec.satisfies("romio-filesystem=none"):
+            args = "+".join(spec.variants["romio-filesystem"].value)
+            config_args.append(f"--with-io-romio-flags=--with-file-system={args}")
+
+        if "+gpfs" in spec:
+            config_args.append("--with-gpfs")
+        else:
+            config_args.append("--with-gpfs=no")
+
+        # SQLite3 support
+        config_args.extend(self.with_or_without("sqlite3"))
+
+        # VampirTrace support
+        if spec.satisfies("@1.3:1"):
+            if "~vt" in spec:
+                config_args.append("--enable-contrib-no-build=vt")
+
+        # Multithreading support
+        config_args.extend(
+            self.enable_or_disable("mpi-thread-multiple", variant="thread_multiple")
+        )
+
+        # CUDA support
+        # See https://www.open-mpi.org/faq/?category=buildcuda
+        if "+cuda" in spec:
+            # OpenMPI dynamically loads libcuda.so, requires dlopen
+            config_args.append("--enable-dlopen")
+            # Searches for header files in DIR/include
+            config_args.append("--with-cuda={0}".format(spec["cuda"].prefix))
+            if spec.satisfies("@1.7:1.7.2"):
+                # This option was removed from later versions
+                config_args.append(
+                    "--with-cuda-libdir={0}".format(spec["cuda"].libs.directories[0])
+                )
+            if spec.satisfies("@5.0:"):
+                # And then it returned
+                config_args.append(
+                    "--with-cuda-libdir={0}".format(spec["cuda"].libs.directories[0] + "/stubs")
+                )
+            if spec.satisfies("@1.7.2"):
+                # There was a bug in 1.7.2 when --enable-static is used
+                config_args.append("--enable-mca-no-build=pml-bfo")
+            if spec.satisfies("%pgi^cuda@7.0:7"):
+                # OpenMPI has problems with CUDA 7 and PGI
+                config_args.append("--with-wrapper-cflags=-D__LP64__ -ta:tesla")
+                if spec.satisfies("%pgi@:15.8"):
+                    # With PGI 15.9 and later compilers, the
+                    # CFLAGS=-D__LP64__ is no longer needed.
+                    config_args.append("CFLAGS=-D__LP64__")
+        elif spec.satisfies("@1.7:"):
+            config_args.append("--without-cuda")
+
+        if spec.satisfies("%nvhpc@:20.11"):
+            # Workaround compiler issues
+            config_args.append("CFLAGS=-O1")
+
+        if "+openshmem" in spec:
+            config_args.append("--enable-oshmem")
+
+        if "+wrapper-rpath" in spec:
+            config_args.append("--enable-wrapper-rpath")
+
+            # Disable new dynamic tags in the wrapper (--disable-new-dtags)
+            # In the newer versions this can be done with a configure option
+            # (for older versions, we rely on filter_compiler_wrappers() and
+            # filter_pc_files()):
+            if spec.satisfies("@3.0.5:"):
+                config_args.append("--disable-wrapper-runpath")
+
+            # Add extra_rpaths and implicit_rpaths into the wrappers.
+            wrapper_ldflags.extend(
+                [
+                    self.compiler.cc_rpath_arg + path
+                    for path in itertools.chain(
+                        self.compiler.extra_rpaths, self.compiler.implicit_rpaths()
+                    )
+                ]
+            )
+        else:
+            config_args.append("--disable-wrapper-rpath")
+            config_args.append("--disable-wrapper-runpath")
+
+        config_args.extend(self.enable_or_disable("mpi-cxx", variant="cxx"))
+        config_args.extend(self.enable_or_disable("cxx-exceptions", variant="cxx_exceptions"))
+
+        if wrapper_ldflags:
+            config_args.append("--with-wrapper-ldflags={0}".format(" ".join(wrapper_ldflags)))
+
+        #
+        # the Spack path padding feature causes issues with Open MPI's lex based parsing system
+        # used by the compiler wrappers.  Crank up lex buffer to 1MB to handle this.
+        # see https://spack.readthedocs.io/en/latest/binary_caches.html#relocation
+        #
+
+        if spec.satisfies("@5.0.0:"):
+            config_args.append("CFLAGS=-DYY_BUF_SIZE=1048576")
+
+        #
+        # disable romio for 5.0.0 or newer if using Intel OneAPI owing to a problem
+        # building ZE related components of the romio packaged with this release
+        #
+
+        #       if spec.satisfies("@5.0.0:") and spec.satisfies("%oneapi"):
+        #           config_args.append("--disable-io-romio")
+
+        # https://www.intel.com/content/www/us/en/developer/articles/release-notes/oneapi-c-compiler-release-notes.html :
+        # Key Features in Intel C++ Compiler Classic 2021.7
+        #
+        # The Intel C++ Classic Compiler is deprecated and an additional
+        # diagnostic message will be output with each invocation. This
+        # diagnostic may impact expected output during compilation. For
+        # example, using the compiler to produce preprocessed information
+        # (icpc -E) will produce the additional deprecation diagnostic,
+        # interfering with the expected preprocessed output.
+        #
+        # This output can be disabled by using -diag-disable=10441 on
+        # Linux/macOS or /Qdiag-disable:10441 on Windows. You can add this
+        # option on the command line, configuration file or option setting
+        # environment variables.
+        if spec.satisfies("%intel@2021.7.0:"):
+            config_args.append("CPPFLAGS=-diag-disable=10441")
+
+        config_args += self.enable_or_disable("debug")
+
+        return config_args
+
+    @run_after("install", when="+wrapper-rpath")
+    def filter_rpaths(self):
+        def filter_lang_rpaths(lang_tokens, rpath_arg):
+            if self.compiler.cc_rpath_arg == rpath_arg:
+                return
+
+            files = find(
+                self.spec.prefix.share.openmpi,
+                ["*{0}-wrapper-data*".format(t) for t in lang_tokens],
+            )
+            files.extend(
+                find(
+                    self.spec.prefix.lib.pkgconfig, ["ompi-{0}.pc".format(t) for t in lang_tokens]
+                )
+            )
+
+            x = FileFilter(*[f for f in files if not os.path.islink(f)])
+
+            # Replace self.compiler.cc_rpath_arg, which have been added as
+            # '--with-wrapper-ldflags', with rpath_arg in the respective
+            # language-specific wrappers and pkg-config files.
+            x.filter(self.compiler.cc_rpath_arg, rpath_arg, string=True, backup=False)
+
+            if self.spec.satisfies("@:1.10.3,2:2.1.1"):
+                # Replace Libtool-style RPATH prefixes '-Wl,-rpath -Wl,' with
+                # rpath_arg for old version of OpenMPI, which assumed that CXX
+                # and FC had the same prefixes as CC.
+                x.filter("-Wl,-rpath -Wl,", rpath_arg, string=True, backup=False)
+
+        filter_lang_rpaths(["c++", "CC", "cxx"], self.compiler.cxx_rpath_arg)
+        filter_lang_rpaths(["fort", "f77", "f90"], self.compiler.fc_rpath_arg)
+
+    @run_after("install", when="@:3.0.4+wrapper-rpath")
+    def filter_pc_files(self):
+        files = find(self.spec.prefix.lib.pkgconfig, "*.pc")
+        x = FileFilter(*[f for f in files if not os.path.islink(f)])
+
+        # Remove this linking flag if present (it turns RPATH into RUNPATH)
+        x.filter(
+            "{0}--enable-new-dtags".format(self.compiler.linker_arg), "", string=True, backup=False
+        )
+
+        # NAG compiler is usually mixed with GCC, which has a different
+        # prefix for linker arguments.
+        if self.compiler.name == "nag":
+            x.filter("-Wl,--enable-new-dtags", "", string=True, backup=False)
+
+    # For v4 and lower
+    @run_after("install")
+    def delete_mpirun_mpiexec(self):
+        # The preferred way to run an application when Slurm is the
+        # scheduler is to let Slurm manage process spawning via PMI.
+        #
+        # Deleting the links to orterun avoids users running their
+        # applications via mpirun or mpiexec, and leaves srun as the
+        # only sensible choice (orterun is still present, but normal
+        # users don't know about that).
+        if self.spec.satisfies("~legacylaunchers schedulers=slurm"):
+            exe_list = [
+                self.prefix.bin.mpirun,
+                self.prefix.bin.mpiexec,
+                self.prefix.bin.shmemrun,
+                self.prefix.bin.oshrun,
+            ]
+            script_stub = join_path(os.path.dirname(__file__), "nolegacylaunchers.sh")
+            for exe in exe_list:
+                try:
+                    os.remove(exe)
+                except OSError:
+                    tty.debug("File not present: " + exe)
+                else:
+                    copy(script_stub, exe)
+
+    @run_after("install")
+    def setup_install_tests(self):
+        """
+        Copy the example files after the package is installed to an
+        install test subdirectory for use during `spack test run`.
+        """
+        cache_extra_test_sources(self, self.extra_install_tests)
+
+    def run_installed_binary(self, bin, options, expected):
+        """run and check outputs for the installed binary"""
+        exe_path = join_path(self.prefix.bin, bin)
+        if not os.path.exists(exe_path):
+            raise SkipTest(f"{bin} is not installed")
+
+        exe = which(exe_path)
+        out = exe(*options, output=str.split, error=str.split)
+        check_outputs(expected, out)
+
+    def test_mpirun(self):
+        """test installed mpirun"""
+        options = ["-n", "1", "ls", ".."]
+        self.run_installed_binary("mpirun", options, [f"openmpi-{self.spec.version}"])
+
+    def test_opmpi_info(self):
+        """test installed ompi_info"""
+        self.run_installed_binary("ompi_info", [], [f"Ident string: {self.spec.version}", "MCA"])
+
+    def test_version(self):
+        """check versions of installed software"""
+        comp_vers = str(self.spec.compiler.version)
+        spec_vers = str(self.spec.version)
+        checks = {
+            # Binaries available in at least versions 2.0.0 through 4.0.3
+            "mpiCC": comp_vers,
+            "mpic++": comp_vers,
+            "mpicc": comp_vers,
+            "mpicxx": comp_vers,
+            "mpiexec": spec_vers,
+            "mpif77": comp_vers,
+            "mpif90": comp_vers,
+            "mpifort": comp_vers,
+            "mpirun": spec_vers,
+            "ompi_info": spec_vers,
+            "ortecc": comp_vers,
+            "orterun": spec_vers,
+        }
+
+        for bin in checks:
+            expected = checks[bin]
+            with test_part(
+                self, f"test_version_{bin}", purpose=f"ensure version of {bin} is {expected}"
+            ):
+                self.run_installed_binary(bin, ["--version"], [expected])
+
+    @property
+    def _cached_tests_work_dir(self):
+        """The working directory for cached test sources."""
+        return join_path(self.test_suite.current_test_cache_dir, self.extra_install_tests)
+
+    def test_example(self):
+        """Run test examples copied from source at build-time."""
+        # Build the copied, cached test examples
+        with test_part(
+            self,
+            "test_example_make",
+            purpose="test: building cached test examples",
+            work_dir=self._cached_tests_work_dir,
+        ):
+            make("all")
+
+        # Run basic examples with known, simple-to-verify results
+        hello_world = ["Hello, world", "I am", "0 of", "1"]
+        ring_out = ["1 processes in ring", "0 exiting"]
+
+        checks = {
+            "hello_c": hello_world,
+            "hello_cxx": hello_world,
+            "hello_mpifh": hello_world,
+            "hello_usempi": hello_world,
+            "hello_usempif08": hello_world,
+            "ring_c": ring_out,
+            "ring_cxx": ring_out,
+            "ring_mpifh": ring_out,
+            "ring_usempi": ring_out,
+            "ring_usempif08": ring_out,
+        }
+
+        for binary in checks:
+            expected = checks[binary]
+            with test_part(
+                self,
+                f"test_example_{binary}",
+                purpose="run and check output",
+                work_dir=self._cached_tests_work_dir,
+            ):
+                exe = which(binary)
+                if not exe:
+                    raise SkipTest(f"{binary} is missing")
+
+                out = exe(output=str.split, error=str.split)
+                check_outputs(expected, out)
+
+
+def get_spack_compiler_spec(compiler):
+    spack_compilers = spack.compilers.find_compilers([os.path.dirname(compiler)])
+    actual_compiler = None
+    # check if the compiler actually matches the one we want
+    for spack_compiler in spack_compilers:
+        if spack_compiler.cc and spack_compiler.cc == compiler:
+            actual_compiler = spack_compiler
+            break
+    return actual_compiler.spec if actual_compiler else None
+
+
+def is_enabled(text):
+    if text in set(["t", "true", "enabled", "yes", "1"]):
+        return True
+    return False

--- a/repo/v0.23/isamrepo/packages/openmpi/pmix_getline_pmix_version-prte.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/pmix_getline_pmix_version-prte.patch
@@ -1,0 +1,14 @@
+diff --git a/3rd-party/prrte/src/tools/prte/prte.c b/3rd-party/prrte/src/tools/prte/prte.c
+index 3c62ef4b66..d15347d324 100644
+--- a/3rd-party/prrte/src/tools/prte/prte.c
++++ b/3rd-party/prrte/src/tools/prte/prte.c
+@@ -256,7 +256,7 @@ static void shutdown_callback(int fd, short flags, void *arg)
+     exit(PRTE_ERROR_DEFAULT_EXIT_CODE);
+ }
+ 
+-#if PMIX_NUMERIC_VERSION < 0x00040208
++#if PMIX_NUMERIC_VERSION < 0x00040205
+ static char *pmix_getline(FILE *fp)
+ {
+     char *ret, *buff;
+

--- a/repo/v0.23/isamrepo/packages/openmpi/pmix_getline_pmix_version.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/pmix_getline_pmix_version.patch
@@ -1,0 +1,52 @@
+diff --git a/3rd-party/prrte/src/mca/ess/base/ess_base_bootstrap.c b/3rd-party/prrte/src/mca/ess/base/ess_base_bootstrap.c
+index 48ce664915..f37bd7bea2 100644
+--- a/3rd-party/prrte/src/mca/ess/base/ess_base_bootstrap.c
++++ b/3rd-party/prrte/src/mca/ess/base/ess_base_bootstrap.c
+@@ -68,7 +68,7 @@ static pmix_status_t regex_parse_value_range(char *base, char *range,
+                                              char ***names);
+ static pmix_status_t read_file(char *regexp, char ***names);
+ 
+-#if PMIX_NUMERIC_VERSION < 0x00040208
++#if PMIX_NUMERIC_VERSION < 0x00040205
+ static char *pmix_getline(FILE *fp)
+ {
+     char *ret, *buff;
+diff --git a/3rd-party/prrte/src/mca/ras/base/ras_base_allocate.c b/3rd-party/prrte/src/mca/ras/base/ras_base_allocate.c
+index bc9db628f5..858f1397fb 100644
+--- a/3rd-party/prrte/src/mca/ras/base/ras_base_allocate.c
++++ b/3rd-party/prrte/src/mca/ras/base/ras_base_allocate.c
+@@ -59,7 +59,7 @@
+ 
+ #include "src/mca/ras/base/ras_private.h"
+ 
+-#if PMIX_NUMERIC_VERSION < 0x00040208
++#if PMIX_NUMERIC_VERSION < 0x00040205
+ static char *pmix_getline(FILE *fp)
+ {
+     char *ret, *buff;
+diff --git a/3rd-party/prrte/src/mca/rmaps/rank_file/rmaps_rank_file.c b/3rd-party/prrte/src/mca/rmaps/rank_file/rmaps_rank_file.c
+index b8316e0a8e..dfd0b847d0 100644
+--- a/3rd-party/prrte/src/mca/rmaps/rank_file/rmaps_rank_file.c
++++ b/3rd-party/prrte/src/mca/rmaps/rank_file/rmaps_rank_file.c
+@@ -71,7 +71,7 @@ static int prte_rmaps_rf_process_lsf_affinity_hostfile(prte_job_t *jdata, prte_r
+ 
+ char *prte_rmaps_rank_file_slot_list = NULL;
+ 
+-#if PMIX_NUMERIC_VERSION < 0x00040208
++#if PMIX_NUMERIC_VERSION < 0x00040205
+ static char *pmix_getline(FILE *fp)
+ {
+     char *ret, *buff;
+diff --git a/3rd-party/prrte/src/mca/rmaps/seq/rmaps_seq.c b/3rd-party/prrte/src/mca/rmaps/seq/rmaps_seq.c
+index 555aa39c42..356fb72aa9 100644
+--- a/3rd-party/prrte/src/mca/rmaps/seq/rmaps_seq.c
++++ b/3rd-party/prrte/src/mca/rmaps/seq/rmaps_seq.c
+@@ -109,7 +109,7 @@ static bool quickmatch(prte_node_t *nd, char *name)
+     return false;
+ }
+ 
+-#if PMIX_NUMERIC_VERSION < 0x00040208
++#if PMIX_NUMERIC_VERSION < 0x00040205
+ static char *pmix_getline(FILE *fp)
+ {
+     char *ret, *buff;

--- a/repo/v0.23/isamrepo/packages/openmpi/use_mpi_tkr_sizeof/step_1.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/use_mpi_tkr_sizeof/step_1.patch
@@ -1,0 +1,584 @@
+--- a/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-interfaces.h
++++ b/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-interfaces.h
+@@ -1650,570 +1650,6 @@ end subroutine MPI_Request_get_status
+ end interface
+ 
+ 
+-interface MPI_Sizeof
+-
+-subroutine MPI_Sizeof0DCH(x, size, ierror)
+-  character, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DCH
+-
+-
+-subroutine MPI_Sizeof0DL(x, size, ierror)
+-  logical, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DL
+-
+-
+-subroutine MPI_Sizeof0DI1(x, size, ierror)
+-  integer*1, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DI1
+-
+-
+-subroutine MPI_Sizeof0DI2(x, size, ierror)
+-  integer*2, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DI2
+-
+-
+-subroutine MPI_Sizeof0DI4(x, size, ierror)
+-  integer*4, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DI4
+-
+-
+-subroutine MPI_Sizeof0DI8(x, size, ierror)
+-  integer*8, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DI8
+-
+-
+-subroutine MPI_Sizeof0DR4(x, size, ierror)
+-  real*4, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DR4
+-
+-
+-subroutine MPI_Sizeof0DR8(x, size, ierror)
+-  real*8, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DR8
+-
+-
+-subroutine MPI_Sizeof0DC8(x, size, ierror)
+-  complex*8, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DC8
+-
+-
+-subroutine MPI_Sizeof0DC16(x, size, ierror)
+-  complex*16, intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof0DC16
+-
+-
+-subroutine MPI_Sizeof1DCH(x, size, ierror)
+-  character, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DCH
+-
+-
+-subroutine MPI_Sizeof1DL(x, size, ierror)
+-  logical, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DL
+-
+-
+-subroutine MPI_Sizeof1DI1(x, size, ierror)
+-  integer*1, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DI1
+-
+-
+-subroutine MPI_Sizeof1DI2(x, size, ierror)
+-  integer*2, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DI2
+-
+-
+-subroutine MPI_Sizeof1DI4(x, size, ierror)
+-  integer*4, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DI4
+-
+-
+-subroutine MPI_Sizeof1DI8(x, size, ierror)
+-  integer*8, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DI8
+-
+-
+-subroutine MPI_Sizeof1DR4(x, size, ierror)
+-  real*4, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DR4
+-
+-
+-subroutine MPI_Sizeof1DR8(x, size, ierror)
+-  real*8, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DR8
+-
+-
+-subroutine MPI_Sizeof1DC8(x, size, ierror)
+-  complex*8, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DC8
+-
+-
+-subroutine MPI_Sizeof1DC16(x, size, ierror)
+-  complex*16, dimension(*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof1DC16
+-
+-
+-subroutine MPI_Sizeof2DCH(x, size, ierror)
+-  character, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DCH
+-
+-
+-subroutine MPI_Sizeof2DL(x, size, ierror)
+-  logical, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DL
+-
+-
+-subroutine MPI_Sizeof2DI1(x, size, ierror)
+-  integer*1, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DI1
+-
+-
+-subroutine MPI_Sizeof2DI2(x, size, ierror)
+-  integer*2, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DI2
+-
+-
+-subroutine MPI_Sizeof2DI4(x, size, ierror)
+-  integer*4, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DI4
+-
+-
+-subroutine MPI_Sizeof2DI8(x, size, ierror)
+-  integer*8, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DI8
+-
+-
+-subroutine MPI_Sizeof2DR4(x, size, ierror)
+-  real*4, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DR4
+-
+-
+-subroutine MPI_Sizeof2DR8(x, size, ierror)
+-  real*8, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DR8
+-
+-
+-subroutine MPI_Sizeof2DC8(x, size, ierror)
+-  complex*8, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DC8
+-
+-
+-subroutine MPI_Sizeof2DC16(x, size, ierror)
+-  complex*16, dimension(1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof2DC16
+-
+-
+-subroutine MPI_Sizeof3DCH(x, size, ierror)
+-  character, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DCH
+-
+-
+-subroutine MPI_Sizeof3DL(x, size, ierror)
+-  logical, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DL
+-
+-
+-subroutine MPI_Sizeof3DI1(x, size, ierror)
+-  integer*1, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DI1
+-
+-
+-subroutine MPI_Sizeof3DI2(x, size, ierror)
+-  integer*2, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DI2
+-
+-
+-subroutine MPI_Sizeof3DI4(x, size, ierror)
+-  integer*4, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DI4
+-
+-
+-subroutine MPI_Sizeof3DI8(x, size, ierror)
+-  integer*8, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DI8
+-
+-
+-subroutine MPI_Sizeof3DR4(x, size, ierror)
+-  real*4, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DR4
+-
+-
+-subroutine MPI_Sizeof3DR8(x, size, ierror)
+-  real*8, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DR8
+-
+-
+-subroutine MPI_Sizeof3DC8(x, size, ierror)
+-  complex*8, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DC8
+-
+-
+-subroutine MPI_Sizeof3DC16(x, size, ierror)
+-  complex*16, dimension(1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof3DC16
+-
+-
+-subroutine MPI_Sizeof4DCH(x, size, ierror)
+-  character, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DCH
+-
+-
+-subroutine MPI_Sizeof4DL(x, size, ierror)
+-  logical, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DL
+-
+-
+-subroutine MPI_Sizeof4DI1(x, size, ierror)
+-  integer*1, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DI1
+-
+-
+-subroutine MPI_Sizeof4DI2(x, size, ierror)
+-  integer*2, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DI2
+-
+-
+-subroutine MPI_Sizeof4DI4(x, size, ierror)
+-  integer*4, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DI4
+-
+-
+-subroutine MPI_Sizeof4DI8(x, size, ierror)
+-  integer*8, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DI8
+-
+-
+-subroutine MPI_Sizeof4DR4(x, size, ierror)
+-  real*4, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DR4
+-
+-
+-subroutine MPI_Sizeof4DR8(x, size, ierror)
+-  real*8, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DR8
+-
+-
+-subroutine MPI_Sizeof4DC8(x, size, ierror)
+-  complex*8, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DC8
+-
+-
+-subroutine MPI_Sizeof4DC16(x, size, ierror)
+-  complex*16, dimension(1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof4DC16
+-
+-
+-subroutine MPI_Sizeof5DCH(x, size, ierror)
+-  character, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DCH
+-
+-
+-subroutine MPI_Sizeof5DL(x, size, ierror)
+-  logical, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DL
+-
+-
+-subroutine MPI_Sizeof5DI1(x, size, ierror)
+-  integer*1, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DI1
+-
+-
+-subroutine MPI_Sizeof5DI2(x, size, ierror)
+-  integer*2, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DI2
+-
+-
+-subroutine MPI_Sizeof5DI4(x, size, ierror)
+-  integer*4, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DI4
+-
+-
+-subroutine MPI_Sizeof5DI8(x, size, ierror)
+-  integer*8, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DI8
+-
+-
+-subroutine MPI_Sizeof5DR4(x, size, ierror)
+-  real*4, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DR4
+-
+-
+-subroutine MPI_Sizeof5DR8(x, size, ierror)
+-  real*8, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DR8
+-
+-
+-subroutine MPI_Sizeof5DC8(x, size, ierror)
+-  complex*8, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DC8
+-
+-
+-subroutine MPI_Sizeof5DC16(x, size, ierror)
+-  complex*16, dimension(1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof5DC16
+-
+-
+-subroutine MPI_Sizeof6DCH(x, size, ierror)
+-  character, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DCH
+-
+-
+-subroutine MPI_Sizeof6DL(x, size, ierror)
+-  logical, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DL
+-
+-
+-subroutine MPI_Sizeof6DI1(x, size, ierror)
+-  integer*1, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DI1
+-
+-
+-subroutine MPI_Sizeof6DI2(x, size, ierror)
+-  integer*2, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DI2
+-
+-
+-subroutine MPI_Sizeof6DI4(x, size, ierror)
+-  integer*4, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DI4
+-
+-
+-subroutine MPI_Sizeof6DI8(x, size, ierror)
+-  integer*8, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DI8
+-
+-
+-subroutine MPI_Sizeof6DR4(x, size, ierror)
+-  real*4, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DR4
+-
+-
+-subroutine MPI_Sizeof6DR8(x, size, ierror)
+-  real*8, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DR8
+-
+-
+-subroutine MPI_Sizeof6DC8(x, size, ierror)
+-  complex*8, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DC8
+-
+-
+-subroutine MPI_Sizeof6DC16(x, size, ierror)
+-  complex*16, dimension(1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof6DC16
+-
+-
+-subroutine MPI_Sizeof7DCH(x, size, ierror)
+-  character, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DCH
+-
+-
+-subroutine MPI_Sizeof7DL(x, size, ierror)
+-  logical, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DL
+-
+-
+-subroutine MPI_Sizeof7DI1(x, size, ierror)
+-  integer*1, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DI1
+-
+-
+-subroutine MPI_Sizeof7DI2(x, size, ierror)
+-  integer*2, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DI2
+-
+-
+-subroutine MPI_Sizeof7DI4(x, size, ierror)
+-  integer*4, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DI4
+-
+-
+-subroutine MPI_Sizeof7DI8(x, size, ierror)
+-  integer*8, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DI8
+-
+-
+-subroutine MPI_Sizeof7DR4(x, size, ierror)
+-  real*4, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DR4
+-
+-
+-subroutine MPI_Sizeof7DR8(x, size, ierror)
+-  real*8, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DR8
+-
+-
+-subroutine MPI_Sizeof7DC8(x, size, ierror)
+-  complex*8, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DC8
+-
+-
+-subroutine MPI_Sizeof7DC16(x, size, ierror)
+-  complex*16, dimension(1,1,1,1,1,1,*), intent(in) :: x
+-  integer, intent(out) :: size
+-  integer, intent(out) :: ierror
+-end subroutine MPI_Sizeof7DC16
+-
+-end interface
+-
+-
+ interface MPI_Start
+ 
+ subroutine MPI_Start(request, ierror)
+--- a/ompi/mpi/fortran/use-mpi-tkr/mpi.F90
++++ b/ompi/mpi/fortran/use-mpi-tkr/mpi.F90
+@@ -50,4 +50,8 @@ module mpi
+ 
+   include "mpi-f90-interfaces.h"
+ 
++#if OMPI_FORTRAN_BUILD_SIZEOF
++  include "mpi-tkr-sizeof.h"
++#endif
++
+ end module mpi

--- a/repo/v0.23/isamrepo/packages/openmpi/use_mpi_tkr_sizeof/step_2.patch
+++ b/repo/v0.23/isamrepo/packages/openmpi/use_mpi_tkr_sizeof/step_2.patch
@@ -1,0 +1,22 @@
+--- a/ompi/mpi/fortran/configure-fortran-output.h.in
++++ b/ompi/mpi/fortran/configure-fortran-output.h.in
+@@ -47,6 +47,8 @@
+ ! Line 2 of the ignore TKR syntax
+ #define OMPI_FORTRAN_IGNORE_TKR_TYPE @OMPI_FORTRAN_IGNORE_TKR_TYPE@
+ 
++
++#define OMPI_FORTRAN_BUILD_SIZEOF @OMPI_FORTRAN_BUILD_SIZEOF@
+ ! Integers
+ 
+ #define OMPI_HAVE_FORTRAN_INTEGER1 @OMPI_HAVE_FORTRAN_INTEGER1@
+--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.in
++++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.in
+@@ -2023,6 +2023,8 @@ uninstall-am: uninstall-libLTLIBRARIES uninstall-local
+ @OMPI_BUILD_FORTRAN_USEMPI_TKR_BINDINGS_TRUE@mpi.lo: $(top_builddir)/ompi/mpi/fortran/configure-fortran-output.h
+ @OMPI_BUILD_FORTRAN_USEMPI_TKR_BINDINGS_TRUE@mpi.lo: mpi-f90-cptr-interfaces.F90
+ 
++@BUILD_FORTRAN_SIZEOF_TRUE@@OMPI_BUILD_FORTRAN_USEMPI_TKR_BINDINGS_TRUE@mpi.lo: mpi-tkr-sizeof.h
++
+ @OMPI_BUILD_FORTRAN_USEMPI_TKR_BINDINGS_TRUE@mpi-tkr-sizeof.h: $(top_builddir)/config.status
+ @OMPI_BUILD_FORTRAN_USEMPI_TKR_BINDINGS_TRUE@mpi-tkr-sizeof.h: $(sizeof_pl)
+ @OMPI_BUILD_FORTRAN_USEMPI_TKR_BINDINGS_TRUE@mpi-tkr-sizeof.h:


### PR DESCRIPTION
OpenMPI for ORCA requires 4.1.8 which this version adds.