### PR TITLE
Add updates for Spack v1.0.

### DIFF
--- a/apps/arm-kernels/3/build.sh
+++ b/apps/arm-kernels/3/build.sh
@@ -4,15 +4,13 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
 
-# Clone Buildit configuration
-#git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -34,10 +32,10 @@ spack config add concretizer:reuse:false
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add arm-kernels
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +44,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which fp64_neon_fmla.x
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/bzip2/3/build.sh
+++ b/apps/bzip2/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
+git clone --depth=2 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add bzip2
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which bzip2
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/castep/3/build.sh
+++ b/apps/castep/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -24,14 +24,14 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
+spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
 spack add castep
@@ -47,3 +47,6 @@ spack env deactivate && spack env activate ./myenv
 
 # Check application is found
 which castep.mpi
+
+# Deactivat eenv
+spack env deactivate

--- a/apps/chapel/3/build.sh
+++ b/apps/chapel/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -24,15 +24,14 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
 spack add chapel

--- a/apps/charmpp/3/build.sh
+++ b/apps/charmpp/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add charmpp
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which charmcc
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/cloverleaf-ref/3/build.sh
+++ b/apps/cloverleaf-ref/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add cloverleaf-ref
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which clover_leaf
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/et/3/build.sh
+++ b/apps/et/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -24,20 +24,20 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
+spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
 spack config add concretizer:reuse:false
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
 spack add et
 
 # Check dependencies
-spack concretize
+spack concretize -f
 
 # Install application
 spack install
@@ -47,3 +47,6 @@ spack env deactivate && spack env activate ./myenv
 
 # Check application is found
 which eT_launch.py
+
+# Deactivate
+spack env deactivate

--- a/apps/hopr/3/build.sh
+++ b/apps/hopr/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -24,14 +24,14 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
+spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
 spack config add concretizer:reuse:false
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
 spack add hopr

--- a/apps/kalign2/3/build.sh
+++ b/apps/kalign2/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add kalign2
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which bzip2
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/libtorch/3/build.sh
+++ b/apps/libtorch/3/build.sh
@@ -34,10 +34,10 @@ spack config add concretizer:reuse:false
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add libtorch
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,7 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which python3
 
 # Deactivate env
 spack env deactivate

--- a/apps/mace-lammps/3/build.sh
+++ b/apps/mace-lammps/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -24,17 +24,17 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
+spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
 spack config add concretizer:reuse:false
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mace-lammps
+spack add mace-lammps ^py-torch@1.13.1~cuda~mpi~mkldnn~valgrind ^openblas
 
 # Check dependencies
 spack concretize
@@ -47,3 +47,6 @@ spack env deactivate && spack env activate ./myenv
 
 # Check application is found
 which python3
+
+# Deactivate env
+spack env deactivate

--- a/apps/minibude/3/build.sh
+++ b/apps/minibude/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
+git clone --depth=2 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,13 +28,13 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add minibude
 
 # Check dependencies
 spack concretize -f
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which serial-bude
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/namd/3/build.sh
+++ b/apps/namd/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -24,23 +24,22 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add view:true
 spack config add concretizer:unify:true
 spack config add concretizer:reuse:false
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
 spack add namd@3.0
 
 # Check dependencies
-spack concretize
+spack concretize --deprecated
 
 # Install application
-spack install
+spack install --deprecated
 
 # Unload and reload environment (to load new view)
 spack env deactivate && spack env activate ./myenv

--- a/apps/neutral/3/build.sh
+++ b/apps/neutral/3/build.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add neutral
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which neutral.omp3
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/openmm/3/build.sh
+++ b/apps/openmm/3/build.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add openmm
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which python
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/orca/3/build.sh
+++ b/apps/orca/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -24,20 +24,20 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
+spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
 spack add orca
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -47,3 +47,7 @@ spack env deactivate && spack env activate ./myenv
 
 # Check application is found
 which orca
+
+# Deactivate environment
+spack env deactivate
+

--- a/apps/osu-micro-benchmarks/3/build.sh
+++ b/apps/osu-micro-benchmarks/3/build.sh
@@ -4,13 +4,15 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
 
 # Clone Buildit configuration
-git clone https://github.com/isambard-sc/buildit.git
+#git clone https://github.com/i/buildit.git
+# Use local copy
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -22,14 +24,14 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
+spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
 spack add osu-micro-benchmarks
@@ -49,5 +51,3 @@ which osu_latency
 # Deactivate environment
 spack env deactivate
 
-
-# 

--- a/apps/piclas/3/build.sh
+++ b/apps/piclas/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch=releases/v0.23 https://github.com/spack/spack.git
+git clone --depth=2 --branch=releases/v1.0 https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -24,17 +24,17 @@ spack env create -d myenv
 spack env activate ./myenv
 
 # Initialise environment
-spack config add -f buildit/config/3/v0.23/linux/compilers.yaml
-spack config add -f buildit/config/3/v0.23/packages.yaml
+spack config add -f buildit/config/3/v1.0/packages.yaml
+spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
 spack config add concretizer:reuse:false
 
 # Add local repo to environment
-spack repo add ./buildit/repo/v0.23/isamrepo
+spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add piclas@master fflags=-fallow-argument-mismatch  eqnsysname=poisson timediscmethod=RK3
+spack add piclas@master eqnsysname=poisson timediscmethod=RK3
 
 # Check dependencies
 spack concretize

--- a/apps/snap/3/build.sh
+++ b/apps/snap/3/build.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add snap
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which snap
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/swiftsim/3/build.sh
+++ b/apps/swiftsim/3/build.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Clone Spack version
-git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
+git clone --depth=2 --branch releases/v1.0  https://github.com/spack/spack.git
 
 # Souce environment
 . spack/share/spack/setup-env.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add swiftsim
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which swift
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/apps/tealeaf/3/build.sh
+++ b/apps/tealeaf/3/build.sh
@@ -12,7 +12,7 @@ git clone --depth=2 --branch releases/v1.0 https://github.com/spack/spack.git
 # Clone Buildit configuration
 #git clone https://github.com/i/buildit.git
 # Use local copy
-ln -s ../../../ ./buildit
+ln -sf ../../../ ./buildit
 
 # Disable local config
 export SPACK_DISABLE_LOCAL_CONFIG=true
@@ -28,16 +28,16 @@ spack config add -f buildit/config/3/v1.0/packages.yaml
 spack config add config:build_jobs:8
 spack config add view:true
 spack config add concretizer:unify:true
-spack config add concretizer:reuse:false
+spack config add concretizer:reuse:true
 
 # Add local repo to environment
 spack repo add ./buildit/repo/v1.0/spack_repo/isamrepo
 
 # Add application
-spack add mpich
+spack add tealeaf
 
 # Check dependencies
-spack concretize -f
+spack concretize
 
 # Install application
 spack install
@@ -46,7 +46,8 @@ spack install
 spack env deactivate && spack env activate ./myenv
 
 # Check application is found
-which mpicc
+which tea_leaf
 
-# Deactivate env
+# Deactivate environment
 spack env deactivate
+

--- a/config/3/v1.0/packages.yaml
+++ b/config/3/v1.0/packages.yaml
@@ -1,0 +1,274 @@
+packages:
+  all:
+    providers:
+      c: [gcc, nvhpc, cce, acfl]
+      cxx: [gcc, nvhpc, cce, acfl]
+      fortran: [gcc, nvhpc, cce, acfl]
+      fftw-api: [cray-fftw, fftw, armpl-gcc, nvpl-fft]
+      blas: [cray-libsci, blis, openblas, armpl-gcc]
+      lapack: [cray-libsci, openblas, armpl-gcc]
+      mpi: [cray-mpich, openmpi]
+      pkgconfig: [pkg-config]
+    permissions:
+      write: group
+  gcc:
+    externals:
+    - spec: gcc@12.3.0 languages='c,c++,fortran'
+      prefix: /usr
+      extra_attributes:
+        compilers:
+          c: /usr/bin/gcc-12
+          cxx: /usr/bin/g++-12
+          fortran: /usr/bin/gfortran-12
+        flags: {}
+    - spec: gcc@13.2.0 languages='c,c++,fortran'
+      prefix: /usr
+      extra_attributes:
+        compilers:
+          c: /usr/bin/gcc-13
+          cxx: /usr/bin/g++-13
+          fortran: /usr/bin/gfortran-13
+        flags: {}
+  cce:
+    externals:
+    - spec: cce@18.0.0
+      prefix: /opt/cray/pe/cce/18.0.0
+      extra_attributes:
+        compilers:
+          c: /opt/cray/pe/cce/18.0.0/bin/craycc
+          cxx: /opt/cray/pe/cce/18.0.0/bin/craycxx
+          fortran: /opt/cray/pe/cce/18.0.0/bin/crayftn
+        flags: {}
+  nvhpc:
+    externals:
+    - spec: nvhpc@24.3
+      prefix: /opt/nvidia/hpc_sdk/Linux_aarch64/24.3/compilers
+      extra_attributes:
+        compilers:
+          c: /opt/nvidia/hpc_sdk/Linux_aarch64/24.3/compilers/bin/nvc
+          cxx: /opt/nvidia/hpc_sdk/Linux_aarch64/24.3/compilers/bin/nvc++
+          fortran: /opt/nvidia/hpc_sdk/Linux_aarch64/24.3/compilers/bin/nvfortran
+        flags:
+          cflags: --gcc-toolchain=/usr/bin/gcc-13 
+          cxxflags: --gcc-toolchain=/usr/bin/gcc-13
+  acfl:
+    externals:
+    - spec: acfl@24.10.1
+      prefix: /opt/arm
+      extra_attributes:
+        compilers:
+          c: /opt/arm/arm-linux-compiler-24.10.1_SLES-15/bin/armclang
+          cxx: /opt/arm/arm-linux-compiler-24.10.1_SLES-15/bin/armclang++
+          fortran: /opt/arm/arm-linux-compiler-24.10.1_SLES-15/bin/armflang
+        flags:
+          cflags: --gcc-toolchain=/opt/arm/gcc-14.2.0_SLES-15
+          cxxflags: --gcc-toolchain=/opt/arm/gcc-14.2.0_SLES-15
+  castep:
+    prefer:
+    - "^openblas ^fftw"
+  chapel:
+    variants: comm=ofi host_platform=linux64 launcher=slurm-srun libfabric=spack comm_ofi_oob=pmi2
+    prefer:
+    - "%gcc"
+    - "^cray-pmi"
+  et:
+    require:
+    - "^openblas +ilp64 ^libint mytune=et"
+  mace-lammps:
+    prefer:
+    - "^py-torch@1.13.1~cuda~mpi~mkldnn~valgrind ^openblas"
+  namd:
+    require:
+    - "^charmpp@8.0.0 backend=ofi pmi=cray-pmi"
+  numactl:
+    require:
+    - "%gcc"
+  xz:
+    require:
+    - "%gcc"
+  openmpi:
+    variants: fabrics=ofi
+  cray-fftw:
+    buildable: false
+    version: [3.3.10.8]
+    externals:
+    - spec: cray-fftw@3.3.10.8
+      prefix: /opt/cray/pe/fftw/3.3.10.8/arm_grace
+  cray-libsci:
+    buildable: false
+    version: [24.07.0]
+    externals:
+    - spec: cray-libsci@24.07.0 %gcc@12.3
+      modules: [cray-libsci]
+      prefix: /opt/cray/pe/libsci/24.07.0/GNU/12.3/aarch64
+    - spec: cray-libsci@24.07.0 %gcc@13.2
+      modules: [cray-libsci]
+      prefix: /opt/cray/pe/libsci/24.07.0/GNU/12.3/aarch64
+    - spec: cray-libsci@24.07.0 %nvhpc@24.3
+      modules: [cray-libsci]
+      prefix: /opt/cray/pe/libsci/24.07.0/NVIDIA/23.11/aarch64
+    - spec: cray-libsci@24.07.0 %cce@18.0.0
+      modules: [cray-libsci]
+      prefix: /opt/cray/pe/libsci/24.07.0/CRAY/17.0/aarch64
+  cray-mpich:
+    buildable: false
+    version: [8.1.30]
+    externals:
+    - spec: cray-mpich@8.1.30 %gcc@12.3
+      prefix: /opt/cray/pe/mpich/8.1.30/ofi/gnu/12.3
+      extra_attributes:
+        environment:
+          prepend_path:
+            LD_LIBRARY_PATH: /opt/cray/libfabric/1.22.0/lib64/
+    - spec: cray-mpich@8.1.30 %gcc@13.2
+      prefix: /opt/cray/pe/mpich/8.1.30/ofi/gnu/12.3
+      extra_attributes:
+        environment:
+          prepend_path:
+            LD_LIBRARY_PATH: /opt/cray/libfabric/1.22.0/lib64/
+    - spec: cray-mpich@8.1.30 %cce@18.0.0
+      prefix: /opt/cray/pe/mpich/8.1.30/ofi/cray/17.0
+      extra_attributes:
+        environment:
+          prepend_path:
+            LD_LIBRARY_PATH: /opt/cray/libfabric/1.22.0/lib64/
+    - spec: cray-mpich@8.1.30 %nvhpc@24.3
+      prefix: /opt/cray/pe/mpich/8.1.30/ofi/nvidia/23.3
+      extra_attributes:
+        environment:
+          prepend_path:
+            LD_LIBRARY_PATH: /opt/cray/libfabric/1.22.0/lib64/
+  cuda:
+    buildable: false
+    version: [12.3.0]
+    externals:
+    - spec: cuda@12.3.0
+      prefix: /opt/nvidia/hpc_sdk/Linux_aarch64/24.3/cuda/12.3
+  libfabric:
+    buildable: false
+    version: [1.22.0]
+    externals:
+    - spec: libfabric@1.22.0 fabrics=cxi
+      prefix: /opt/cray/libfabric/1.22.0
+      modules: [libfabric/1.22.0]
+  cray-pmi:
+    buildable: false
+    version: [6.1.15]
+    externals:
+    - spec: cray-pmi@6.1.15
+      prefix: /opt/cray/pe/pmi/6.1.15
+      modules: [cray-pmi/6.1.15]
+  python:
+    externals:
+    - spec: python@3.11.7
+      prefix: /opt/cray/pe/python/3.11.7
+      modules: [cray-python/3.11.7]
+  autoconf:
+    externals:
+    - prefix: /usr
+      spec: autoconf@2.69
+  automake:
+    externals:
+    - prefix: /usr
+      spec: automake@1.15.1
+  binutils:
+    externals:
+    - prefix: /usr
+      spec: binutils@2.41.0~gold~headers
+  bison:
+    externals:
+    - prefix: /usr
+      spec: bison@3.0.4
+  cmake:
+    externals:
+    - prefix: /usr
+      spec: cmake@3.20.4
+  coreutils:
+    externals:
+    - prefix: /usr
+      spec: coreutils@8.32
+  curl:
+    externals:
+    - prefix: /usr
+      spec: curl@8.0.1+gssapi+ldap+nghttp2
+  cvs:
+    externals:
+    - prefix: /usr
+      spec: cvs@1.12.13
+  diffutils:
+    externals:
+    - prefix: /usr
+      spec: diffutils@3.6
+  findutils:
+    externals:
+    - prefix: /usr
+      spec: findutils@4.8.0
+  flex:
+    externals:
+    - prefix: /usr
+      spec: flex@2.6.4+lex
+  gawk:
+    externals:
+    - prefix: /usr
+      spec: gawk@4.2.1
+  gettext:
+    externals:
+    - prefix: /usr
+      spec: gettext@0.20.2
+  git:
+    externals:
+    - prefix: /usr
+      spec: git@2.35.3+tcltk
+  gmake:
+    externals:
+    - prefix: /usr
+      spec: gmake@4.2.1
+  groff:
+    externals:
+    - prefix: /usr
+      spec: groff@1.22.4
+  libtool:
+    externals:
+    - prefix: /usr
+      spec: libtool@2.4.6
+  m4:
+    externals:
+    - prefix: /usr
+      spec: m4@1.4.18
+  openssh:
+    externals:
+    - prefix: /usr
+      spec: openssh@8.4p1
+  openssl:
+    externals:
+    - prefix: /usr
+      spec: openssl@1.1.1l-fips
+  perl:
+    externals:
+    - prefix: /usr
+      spec: perl@5.26.1~cpanm+opcode+open+shared+threads
+  pkg-config:
+    externals:
+    - prefix: /usr
+      spec: pkg-config@0.29.2
+  rsync:
+    externals:
+    - prefix: /usr
+      spec: rsync@3.2.3
+  sed:
+    externals:
+    - prefix: /usr
+      spec: sed@4.4
+  subversion:
+    externals:
+    - prefix: /usr
+      spec: subversion@1.14.1
+  tar:
+    externals:
+    - prefix: /usr
+      spec: tar@1.34
+  zlib:
+    externals:
+    - prefix: /usr
+      spec: zlib@1.2.13
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/arm_kernels/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/arm_kernels/package.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+class ArmKernels(MakefilePackage):
+    """Optimized primitives for collective multi-GPU communication."""
+
+    homepage = "https://github.com/NVIDIA/arm-kernels"
+    git = "https://github.com/NVIDIA/arm-kernels.git"
+    maintainers("green-br")
+
+    version("main", branch="main")
+    depends_on("cxx", type="build")
+
+    def patch(self):
+        filter_file(
+            r"CXX = .*",
+            "", 
+            "config.mk",
+        )
+        filter_file(
+            r"CXXFLAGS = .*",
+            "",
+            "config.mk",
+        )
+        target = self.spec.target
+        if "sve" not in target.features:
+            filter_file(
+                r"^.*_sve_.*\.x.*",
+                "	\\",
+                "arithmetic/Makefile",
+            )
+        if "fphp" not in target.features:
+            filter_file(
+                r"^.*fp16_.*\.x.*",
+                "	\\",
+                "arithmetic/Makefile",
+            )
+
+
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install_tree("arithmetic", prefix.bin)
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/castep/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/castep/package.py
@@ -1,0 +1,185 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Castep(MakefilePackage):
+    """
+    CASTEP is a leading code for calculating the
+    properties of materials from first principles.
+    Using density functional theory, it can simulate
+    a wide range of properties of materials
+    proprieties including energetics, structure at
+    the atomic level, vibrational properties,
+    electronic response properties etc.
+    """
+
+    homepage = "http://castep.org"
+    url = f"file://{os.getcwd()}/CASTEP-25.11.tar.gz"
+    manual_download = True
+
+    version("25.1.1", sha256="af6851a973ef83bbd725f6f33ff7616dd9d589bd75cf74cd106b13c3369167f6")
+    version("24.1",   sha256="97d77a4f3ce3f5c5b87e812f15a2c2cb23918acd7034c91a872b6d66ea0f7dbb")
+    version("23.1",   sha256="7fba0450d3fd71586c8498ce51975bbdde923759ab298a656409280c29bf45b5")
+    version("22.1.1", sha256="aca3fc2207c677561293585a4edaf233676a759c5beb8389cf938411226ef1f5")
+    version("21.1.1", sha256="d909936a51dd3dff7a0847c2597175b05c8d0018d5afe416737499408914728f")
+    version("20.1.1", sha256="d5e4e5503899db2820e992262df2b910227a5f50e8dd2544ffb6d7e5d6bf53e9")
+    version("19.1.1", sha256="116e24904f78f7433686244134bd53d0275bede95fefb039afc907ab6b025ead")
+
+    variant("mpi", default=True, description="Enable MPI build")
+    
+    # depend on compilers
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+
+    # seems to only need python
+    depends_on("python", when="@24.1:")
+
+    # distutils (removed at Python 3.12) is required at these versions
+    depends_on("python@3.6:3.11", when="@:23.1")
+    depends_on("py-setuptools", when="@:23.1")
+    
+    depends_on("rsync", type="build")
+    depends_on("blas")
+    depends_on("lapack")
+    depends_on("fftw-api")
+    depends_on("mpi", type=("build", "link", "run"), when="+mpi")
+
+    parallel = True
+
+    def url_version(self, version):
+        split_ver = str(version).split(".")
+        url_version = ".".join(split_ver[:2])
+        if len(split_ver) == 3:
+            url_version = url_version+split_ver[2]
+        if url_version == "20.11":
+            url_version = "20.11-repack1"
+        return url_version
+
+    def casteparch(self, spec):
+        if spec.satisfies("platform=linux"):
+            if spec.satisfies("target=x86_64:"):
+                archtype="linux_x86_64"
+            elif spec.satisfies("target=aarch64:"):
+                archtype="linux_aarch64"
+            else:
+                raise InstallError("This package currently supports x86_64 and aarch64!")
+
+        else:
+            raise InstallError("This package only supports Linux!")
+
+        # Compiler is dependent on version of Castep
+        if spec.satisfies("%intel"):
+            if spec.satisfies("@:19"):
+                archtype=f"{archtype}_ifort19"
+            elif spec.satisfies("@20:"):
+                archtype=f"{archtype}_ifort"
+            else:
+                raise InstallError("Please add support for this version!")
+        elif spec.satisfies("%gcc"): 
+            if spec.satisfies("@:19"):
+                archtype=f"{archtype}_gfortran9.0"
+            elif spec.satisfies("@20:"):
+                archtype=f"{archtype}_gfortran10"
+            else:
+                raise InstallError("Please add support for this version!")
+        elif spec.satisfies("%nvhpc"): 
+            if spec.satisfies("@25:"):
+                archtype=f"{archtype}_nvfortran"
+            else:
+                raise InstallError("Please add support for this version!")
+        elif spec.satisfies("%cce"):
+            if spec.satisfies("@19:"):
+                archtype=f"{archtype}_cray-XT"
+            else:
+                raise InstallError("Please add support for this version!")
+        else:
+            raise InstallError("Please add support for this compiler!")
+        return archtype
+
+    def edit(self, spec, prefix):
+        archtype = self.casteparch(spec)
+        platfile = FileFilter(f"obj/platforms/{archtype}.mk")
+        
+        if (
+            spec.satisfies("@:19")
+            and spec.satisfies("target=aarch64:")
+        ):
+            # aarch64 makefile doesnt exist at this version/
+            cp = which("cp")
+            cp("obj/platforms/linux_x86_64_gfortran9.0.mk",
+               f"obj/platforms/{archtype}.mk")
+
+        if spec.satisfies("%gcc"):
+            if self.spec.satisfies("@:19"):
+                dlmakefile = FileFilter("LibSource/dl_mg-2.0.3/platforms/castep.inc")
+                dlmakefile.filter(r"MPIFLAGS = -DMPI", "MPIFLAGS = -fallow-argument-mismatch -DMPI")
+
+                platfile.filter(r"^\s*FFLAGS_E\s*=.*", "FFLAGS_E = -fallow-argument-mismatch ")
+
+        if spec.satisfies("%nvhpc"):
+            platfile.filter(r"^FFLAGS_MODULES = ", "FFLAGS_MODULES = -Mbackslash ")
+        if spec.satisfies("^cray-libsci"):
+            platfile.filter(r"MATH_LIBS = \n", f"MATH_LIBS = {spec['cray-libsci'].libs.link_flags}\n")
+            platfile.filter(r"MATH_LIBS = -llapack -lblas", f"MATH_LIBS = {spec['cray-libsci'].libs.link_flags}")
+
+        platfile.filter(r"^\s*OPT_CPU\s*=.*", "OPT_CPU = ")
+
+    @property
+    def build_targets(self):
+        spec = self.spec
+        targetlist = [f"PWD={self.stage.source_path}"]
+        archtype = self.casteparch(spec)
+        
+        if spec.satisfies("+mpi"):
+            targetlist.append("COMMS_ARCH=mpi")
+            targetlist.append(f"F90={spec['mpi'].mpifc}")
+            targetlist.append(f"CC={spec['mpi'].mpicc}")
+        else:
+            targetlist.append(f"F90={spack_fc}")
+            targetlist.append(f"CC={spack_cc}")
+
+        targetlist.append(f"FFTLIBDIR={spec['fftw-api'].prefix.lib}")
+        targetlist.append(f"MATHLIBDIR={spec['blas'].prefix.lib}")
+
+        if spec.satisfies("^mkl"):
+            targetlist.append("FFT=mkl")
+            if self.spec.satisfies("@20:"):
+                targetlist.append("MATHLIBS=mkl")
+            else:
+                targetlist.append("MATHLIBS=mkl10")
+
+        if spec.satisfies("^openblas"):
+            targetlist.append("MATHLIBS=openblas")
+        elif spec.satisfies("^cray-libsci"):
+            if spec.satisfies("%cce"):
+                # Assumed only CCE
+                targetlist.append("MATHLIBS=scilib")
+            else:
+                # Default patched earlier.
+                targetlist.append("MATHLIBS=default")
+
+
+        if spec.satisfies("^fftw"):
+            targetlist.append("FFT=fftw3")
+        elif spec.satisfies("^cray-fftw"):
+            targetlist.append("FFT=fftw3")
+        
+        if not any("FFT=" in s for s in targetlist):
+            raise InstallError("Castep FFT only supports certain dependencies!")
+        if not any("MATHLIBS=" in s for s in targetlist):
+            raise InstallError("Castep MATHLIBS only supports certain dependencies!")
+
+        targetlist.append(f"ARCH={archtype}")
+
+        return targetlist
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        make("install", "install-tools", *self.build_targets, "INSTALL_DIR={0}".format(prefix.bin))

--- a/repo/v1.0/spack_repo/isamrepo/packages/chapel/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/chapel/package.py
@@ -1,0 +1,70 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package_base import PackageBase # Or other base class
+
+# Import the original Mpich class from the 'builtin' repository
+from spack_repo.builtin.packages.chapel.package import Chapel as BuiltinChapel
+
+from spack.package import *
+
+class Chapel(BuiltinChapel):
+    variant(
+        "comm_ofi_oob",
+        values=("sockets", "mpi", "pmi2"),
+        default="sockets",
+        description="Select out-of-band support",
+        multi=False,
+    )
+
+    chpl_env_vars = [
+        "CHPL_ATOMICS",
+        "CHPL_AUX_FILESYS",
+        "CHPL_COMM",
+        "CHPL_COMM_OFI_OOB",
+        "CHPL_COMM_SUBSTRATE",
+        "CHPL_DEVELOPER",
+        "CHPL_GASNET_SEGMENT",
+        "CHPL_GMP",
+        "CHPL_GPU",
+        "CHPL_GPU_ARCH",
+        "CHPL_GPU_MEM_STRATEGY",
+        "CHPL_HOME",
+        "CHPL_HOST_ARCH",
+        # "CHPL_HOST_CC",
+        "CHPL_HOST_COMPILER",
+        # "CHPL_HOST_CXX",
+        "CHPL_HOST_JEMALLOC",
+        "CHPL_HOST_MEM",
+        "CHPL_HOST_PLATFORM",
+        "CHPL_HWLOC",
+        "CHPL_LAUNCHER",
+        "CHPL_LIB_PIC",
+        "CHPL_LIBFABRIC",
+        "CHPL_LLVM",
+        "CHPL_LLVM_CONFIG",
+        "CHPL_LLVM_SUPPORT",
+        "CHPL_LLVM_VERSION",
+        "CHPL_LOCALE_MODEL",
+        "CHPL_MEM",
+        "CHPL_RE2",
+        "CHPL_SANITIZE",
+        "CHPL_SANITIZE_EXE",
+        "CHPL_TARGET_ARCH",
+        # "CHPL_TARGET_CC",
+        "CHPL_TARGET_COMPILER",
+        "CHPL_TARGET_CPU",
+        # "CHPL_TARGET_CXX",
+        "CHPL_TARGET_PLATFORM",
+        "CHPL_TASKS",
+        "CHPL_TIMERS",
+        "CHPL_UNWIND",
+    ]
+
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        super().setup_run_environment(env) # Call parent method
+        env.set("CHPL_RT_MAX_HEAP_SIZE", "10g")
+
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/charm_6.7.1_aocc.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/charm_6.7.1_aocc.patch
@@ -1,0 +1,188 @@
+diff -bur charm-6.7.1/src/arch/mpi-linux-x86_64/cc-mpicxx.sh updated-charm-6.7.1/src/arch/mpi-linux-x86_64/cc-mpicxx.sh
+--- charm-6.7.1/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2016-11-07 20:14:26.000000000 +0530
++++ updated-charm-6.7.1/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2019-08-26 16:55:40.868903291 +0530
+@@ -14,7 +14,7 @@
+ 
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "$CMK_REAL_COMPILER" in
+-g++)   CMK_AMD64="-m64 -fPIC" ;;
++clang++)   CMK_AMD64="-m64 -fPIC" ;;
+ icpc)  CMK_AMD64="-m64";;
+ pgCC)  CMK_AMD64="-DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std " ;;
+ FCC)   CMK_AMD64="-Kfast -DCMK_FIND_FIRST_OF_PREDICATE=1 --variadic_macros";;
+diff -bur charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh updated-charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh
+--- charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh	2016-11-07 20:14:26.000000000 +0530
++++ updated-charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh	2019-08-26 16:55:40.868903291 +0530
+@@ -1,14 +1,14 @@
+ 
+ case "$CMK_CC" in
+ mpicc*)
+-	CMK_CPP_C="gcc -E "
+-	CMK_CC="gcc -fPIC"
+-	CMK_CC_RELIABLE="gcc  -fPIC"
+-	CMK_CC_FASTEST="gcc  -fPIC"
+-	CMK_CXX="g++ -fPIC"
+-	CMK_CXXPP="gcc -E "
+-	CMK_LD="gcc"
+-	CMK_LDXX="g++"
++	CMK_CPP_C="clang -E "
++	CMK_CC="clang -fPIC"
++	CMK_CC_RELIABLE="clang  -fPIC"
++	CMK_CC_FASTEST="clang  -fPIC"
++	CMK_CXX="clang++ -fPIC"
++	CMK_CXXPP="clang -E "
++	CMK_LD="clang"
++	CMK_LDXX="clang++"
+ 
+ # native compiler for compiling charmxi, etc
+ 	CMK_NATIVE_CC="$CMK_CC"
+Only in updated-charm-6.7.1/src/arch/mpi-linux-x86_64: conv-mach-scyld.sh.orig
+Only in updated-charm-6.7.1/src/arch/mpi-linux-x86_64: conv-mach-scyld.sh.rej
+diff -bur charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach.sh updated-charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach.sh
+--- charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach.sh	2016-11-07 20:14:26.000000000 +0530
++++ updated-charm-6.7.1/src/arch/mpi-linux-x86_64/conv-mach.sh	2019-08-26 16:55:40.868903291 +0530
+@@ -23,7 +23,7 @@
+ 
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "$CMK_REAL_COMPILER" in
+-g++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
++clang++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
+ pgCC)  CMK_AMD64_CC="-fPIC"; CMK_AMD64_CXX="-fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std " ;;
+ charmc)  echo "Error> charmc can not call AMPI's mpicxx/mpiCC wrapper! Please fix your PATH."; exit 1 ;;
+ esac
+@@ -38,10 +38,10 @@
+ CMK_LIBS="-lckqt $CMK_SYSLIBS "
+ CMK_LD_LIBRARY_PATH="-Wl,-rpath,$CHARMLIBSO/"
+ 
+-CMK_NATIVE_CC="gcc $CMK_GCC64 "
+-CMK_NATIVE_LD="gcc $CMK_GCC64 "
+-CMK_NATIVE_CXX="g++ $CMK_GCC64 "
+-CMK_NATIVE_LDXX="g++ $CMK_GCC64 "
++CMK_NATIVE_CC="clang $CMK_GCC64 "
++CMK_NATIVE_LD="clang $CMK_GCC64 "
++CMK_NATIVE_CXX="clang++ $CMK_GCC64 "
++CMK_NATIVE_LDXX="clang++ $CMK_GCC64 "
+ CMK_NATIVE_LIBS=""
+ 
+ # fortran compiler 
+@@ -51,7 +51,7 @@
+ #    CMK_FPP="/lib/cpp -P -CC"
+ #    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
+ #    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
+-#    CMK_F90LIBS="-lgfortran "
++#    CMK_F90LIBS="  "
+ #    CMK_F90_USE_MODDIR=1
+ #    CMK_F90_MODINC="-I"
+ #    CMK_MOD_NAME_ALLCAPS=
+diff -bur charm-6.7.1/src/libs/ck-libs/ckloop/Makefile updated-charm-6.7.1/src/libs/ck-libs/ckloop/Makefile
+--- charm-6.7.1/src/libs/ck-libs/ckloop/Makefile	2016-11-07 20:14:28.000000000 +0530
++++ updated-charm-6.7.1/src/libs/ck-libs/ckloop/Makefile	2019-08-26 16:55:40.852903122 +0530
+@@ -38,7 +38,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+Only in updated-charm-6.7.1/src/libs/ck-libs/ckloop: Makefile.orig
+Only in updated-charm-6.7.1/src/libs/ck-libs/ckloop: Makefile.rej
+diff -bur charm-6.7.1/src/libs/ck-libs/completion/Makefile updated-charm-6.7.1/src/libs/ck-libs/completion/Makefile
+--- charm-6.7.1/src/libs/ck-libs/completion/Makefile	2016-11-07 20:14:28.000000000 +0530
++++ updated-charm-6.7.1/src/libs/ck-libs/completion/Makefile	2019-08-26 16:55:40.852903122 +0530
+@@ -45,7 +45,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+Only in updated-charm-6.7.1/src/libs/ck-libs/completion: Makefile.orig
+Only in updated-charm-6.7.1/src/libs/ck-libs/completion: Makefile.rej
+diff -bur charm-6.7.1/src/libs/ck-libs/multicast/Makefile updated-charm-6.7.1/src/libs/ck-libs/multicast/Makefile
+--- charm-6.7.1/src/libs/ck-libs/multicast/Makefile	2016-11-07 20:14:29.000000000 +0530
++++ updated-charm-6.7.1/src/libs/ck-libs/multicast/Makefile	2019-08-26 16:55:40.852903122 +0530
+@@ -53,7 +53,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+Only in updated-charm-6.7.1/src/libs/ck-libs/multicast: Makefile.orig
+Only in updated-charm-6.7.1/src/libs/ck-libs/multicast: Makefile.rej
+diff -bur charm-6.7.1/src/libs/ck-libs/NDMeshStreamer/Makefile updated-charm-6.7.1/src/libs/ck-libs/NDMeshStreamer/Makefile
+--- charm-6.7.1/src/libs/ck-libs/NDMeshStreamer/Makefile	2016-11-07 20:14:27.000000000 +0530
++++ updated-charm-6.7.1/src/libs/ck-libs/NDMeshStreamer/Makefile	2019-08-26 16:55:40.852903122 +0530
+@@ -52,7 +52,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp -I../completion $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp -I../completion $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done;
+ 
+Only in updated-charm-6.7.1/src/libs/ck-libs/NDMeshStreamer: Makefile.orig
+Only in updated-charm-6.7.1/src/libs/ck-libs/NDMeshStreamer: Makefile.rej
+diff -bur charm-6.7.1/src/QuickThreads/Makefile updated-charm-6.7.1/src/QuickThreads/Makefile
+--- charm-6.7.1/src/QuickThreads/Makefile	2016-11-07 20:14:25.000000000 +0530
++++ updated-charm-6.7.1/src/QuickThreads/Makefile	2019-08-26 16:55:40.856903165 +0530
+@@ -1,5 +1,5 @@
+ 
+-CC=gcc -I. -O2
++CC=clang -I. -O2
+ 
+ all: qt stp testpgm
+ 
+diff -bur charm-6.7.1/src/scripts/Makefile updated-charm-6.7.1/src/scripts/Makefile
+--- charm-6.7.1/src/scripts/Makefile	2016-11-07 20:14:29.000000000 +0530
++++ updated-charm-6.7.1/src/scripts/Makefile	2019-08-26 16:55:40.840902996 +0530
+@@ -942,7 +942,7 @@
+ 	      SRCFILE=`basename $$i .o`.C ; \
+ 	      [ ! -f $$SRCFILE ] && SRCFILE=`basename $$i .o`.c ;	\
+               echo "checking dependencies for $$SRCFILE" ; \
+-              if g++ -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
++              if clang++ -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
+ 	      echo '' >> $(DEPENDFILE) ; \
+         done;  \
+ 
+@@ -968,7 +968,7 @@
+ 	      found=`/usr/bin/find $$SRCDIR -depth 1 -name $$SRCFILE`; \
+               [ ! $$found ] && SRCFILE=`basename $$i .o`.c ; \
+               echo "checking dependencies for $$SRCFILE" ; \
+-              if g++ -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
++              if clang++ -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
+ 	      echo '' >> $(DEPENDFILE) ; \
+         done;  \
+ 
+diff -bur charm-6.7.1/tests/charm++/megatest/Makefile updated-charm-6.7.1/tests/charm++/megatest/Makefile
+--- charm-6.7.1/tests/charm++/megatest/Makefile	2016-11-07 20:14:30.000000000 +0530
++++ updated-charm-6.7.1/tests/charm++/megatest/Makefile	2019-08-26 16:55:40.820902785 +0530
+@@ -118,7 +118,7 @@
+         for i in $(OBJS) ; do \
+               SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$SRCFILE" ; \
+-              g++ -MM -I$(CHARMINC) $$SRCFILE | \
++              clang++ -MM -I$(CHARMINC) $$SRCFILE | \
+               perl $(CHARMBIN)/dep.pl $(CHARMINC) /usr/include /usr/local >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done;
+--- charm-6.7.1/src/scripts/configure	2016-11-07 20:14:31.000000000 +0530
++++ updated-charm/charm-6.7.1/src/scripts/configure	2020-10-21 12:54:06.476958828 +0530
+@@ -2141,8 +2141,8 @@
+ $as_echo_n "checking \"$1\"... " >&6; }
+ 	echo "### $1" >> $charmout
+ 	cat $t >> $charmout
+-	echo $CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -c $t -o test.o $4 >> $charmout
+-	$CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -c $t -o test.o $4 > out 2>&1
++	echo $CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -Qunused-arguments -c $t -o test.o $4 >> $charmout
++	$CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -Qunused-arguments  -c $t -o test.o $4 > out 2>&1
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/charm_6.8.2_aocc.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/charm_6.8.2_aocc.patch
@@ -1,0 +1,165 @@
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/cc-mpicxx.sh 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/cc-mpicxx.sh
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2018-01-11 19:06:19.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/cc-mpicxx.sh	2019-11-12 06:02:23.005454343 -0600
+@@ -15,6 +15,7 @@
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "$CMK_REAL_COMPILER" in
+ g++)   CMK_AMD64="-m64 -fPIC" ;;
++clang++)   CMK_AMD64="-m64 -fPIC" ;;
+ icpc)  CMK_AMD64="-m64";;
+ pgCC)  CMK_AMD64="-DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std " ;;
+ FCC)   CMK_AMD64="-Kfast -DCMK_FIND_FIRST_OF_PREDICATE=1 --variadic_macros";;
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh	2018-01-11 19:06:19.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach-scyld.sh	2019-11-12 06:05:22.666969636 -0600
+@@ -1,13 +1,14 @@
+ 
+ case "$CMK_CC" in
+ mpicc*)
+-	CMK_CPP_C="gcc -E "
+-	CMK_CC="gcc -fPIC"
+-	CMK_CC_RELIABLE="gcc  -fPIC"
+-	CMK_CC_FASTEST="gcc  -fPIC"
+-	CMK_CXX="g++ -fPIC"
+-	CMK_LD="gcc"
+-	CMK_LDXX="g++"
++	CMK_CPP_C="clang -E "
++	CMK_CC="clang -fPIC"
++	CMK_CC_RELIABLE="clang  -fPIC"
++	CMK_CC_FASTEST="clang  -fPIC"
++	CMK_CXXPP="clang -E "
++	CMK_CXX="clang++ -fPIC"
++	CMK_LD="clang"
++	CMK_LDXX="clang++"
+ 
+ # native compiler for compiling charmxi, etc
+ 	CMK_NATIVE_CC="$CMK_CC"
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach.sh 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach.sh
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach.sh	2018-01-11 19:06:19.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/arch/mpi-linux-x86_64/conv-mach.sh	2019-11-12 06:07:41.361999246 -0600
+@@ -23,6 +23,7 @@
+ 
+ CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
+ case "$CMK_REAL_COMPILER" in
++clang++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
+ g++) CMK_AMD64_CC="$CMK_GCC64"; CMK_AMD64_CXX="$CMK_GCC64" ;;
+ pgCC)  CMK_AMD64_CC='-fPIC'; CMK_AMD64_CXX='-fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std ' ;;
+ charmc)  echo "Error> charmc can not call AMPI's mpicxx/mpiCC wrapper! Please fix your PATH."; exit 1 ;;
+@@ -37,10 +38,10 @@
+ CMK_LIBS="-lckqt $CMK_SYSLIBS "
+ CMK_LD_LIBRARY_PATH="-Wl,-rpath,$CHARMLIBSO/"
+ 
+-CMK_NATIVE_CC="gcc $CMK_GCC64 "
+-CMK_NATIVE_LD="gcc $CMK_GCC64 "
+-CMK_NATIVE_CXX="g++ $CMK_GCC64 "
+-CMK_NATIVE_LDXX="g++ $CMK_GCC64 "
++CMK_NATIVE_CC="clang $CMK_GCC64 "
++CMK_NATIVE_LD="clang $CMK_GCC64 "
++CMK_NATIVE_CXX="clang++ $CMK_GCC64 "
++CMK_NATIVE_LDXX="clang++ $CMK_GCC64 "
+ CMK_NATIVE_LIBS=''
+ 
+ # fortran compiler
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/ckloop/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/ckloop/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/ckloop/Makefile	2018-01-11 19:06:15.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/ckloop/Makefile	2019-11-12 06:09:16.200438412 -0600
+@@ -38,7 +38,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/completion/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/completion/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/completion/Makefile	2018-01-11 19:06:16.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/completion/Makefile	2019-11-12 06:09:41.247346697 -0600
+@@ -45,7 +45,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done; 
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/NDMeshStreamer/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/NDMeshStreamer/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/NDMeshStreamer/Makefile	2018-01-11 19:06:15.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/libs/ck-libs/NDMeshStreamer/Makefile	2019-11-12 06:09:59.079993368 -0600
+@@ -52,7 +52,7 @@
+         for i in $(LIBOBJ) ; do \
+ 	      SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$i : $$SRCFILE" ; \
+-              g++ -MM -Wno-deprecated -I$(CDIR)/tmp -I../completion $$SRCFILE >> $(DEPENDFILE); \
++              clang++ -MM -Wno-deprecated -I$(CDIR)/tmp -I../completion $$SRCFILE >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -I$(CDIR)/tmp -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done;
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/QuickThreads/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/QuickThreads/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/QuickThreads/Makefile	2018-01-11 19:06:13.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/QuickThreads/Makefile	2019-11-12 06:10:37.744395459 -0600
+@@ -1,5 +1,5 @@
+ 
+-CC=gcc -I. -O2
++CC=clang -I. -O2
+ 
+ all: qt stp testpgm
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/src/scripts/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/scripts/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/scripts/Makefile	2018-01-11 19:06:20.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/scripts/Makefile	2019-11-12 06:10:59.888198461 -0600
+@@ -962,7 +962,7 @@
+ 	      SRCFILE=`basename $$i .o`.C ; \
+ 	      [ ! -f $$SRCFILE ] && SRCFILE=`basename $$i .o`.c ;	\
+               echo "checking dependencies for $$SRCFILE" ; \
+-              if g++ -std=c++0x -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
++              if clang++ -std=c++0x -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
+ 	      echo '' >> $(DEPENDFILE) ; \
+         done;  \
+ 
+@@ -988,7 +988,7 @@
+ 	      found=`/usr/bin/find $$SRCDIR -depth 1 -name $$SRCFILE`; \
+               [ ! $$found ] && SRCFILE=`basename $$i .o`.c ; \
+               echo "checking dependencies for $$SRCFILE" ; \
+-              if g++ -std=c++0x -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
++              if clang++ -std=c++0x -MM -Wno-deprecated -I. -I$(INC) $$SRCFILE  >> $(DEPENDFILE); then true ; else echo '' ; echo "Compilation of '$$SRCFILE' failed, please fix it first!!!!" ; exit; fi;  \
+ 	      echo '' >> $(DEPENDFILE) ; \
+         done;  \
+ 
+diff -ruN 00/NAMD_2.13_Source/charm-6.8.2/tests/charm++/megatest/Makefile 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/tests/charm++/megatest/Makefile
+--- 00/NAMD_2.13_Source/charm-6.8.2/tests/charm++/megatest/Makefile	2018-01-11 19:06:18.000000000 -0600
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/tests/charm++/megatest/Makefile	2019-11-12 06:11:38.193587531 -0600
+@@ -116,7 +116,7 @@
+         for i in $(OBJS) ; do \
+               SRCFILE=`basename $$i .o`.C ; \
+               echo "checking dependencies for $$SRCFILE" ; \
+-              g++ -std=c++0x -MM -I$(CHARMINC) $$SRCFILE | \
++              clang++ -std=c++0x -MM -I$(CHARMINC) $$SRCFILE | \
+               perl $(CHARMBIN)/dep.pl $(CHARMINC) /usr/include /usr/local >> $(DEPENDFILE); \
+               echo '	$$(CHARMC) -o '$$i $$SRCFILE >> $(DEPENDFILE) ; \
+         done;
+--- 00/NAMD_2.13_Source/charm-6.8.2/src/scripts/configure	2018-01-12 06:36:21.000000000 +0530
++++ 00_aocc-patch/NAMD_2.13_Source/charm-6.8.2/src/scripts/configure	2020-10-21 15:01:20.240748316 +0530
+@@ -2183,8 +2183,8 @@
+ $as_echo_n "checking \"$1\"... " >&6; }
+ 	echo "### $1" >> $charmout
+ 	cat $tc >> $charmout
+-	echo $CMK_CC -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CC $OPTS_LD -c $tc -o test.o $4 >> $charmout
+-	$CMK_CC -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CC $OPTS_LD -c $tc -o test.o $4 > out 2>&1
++	echo $CMK_CC -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CC $OPTS_LD -Qunused-arguments -c $tc -o test.o $4 >> $charmout
++	$CMK_CC -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CC $OPTS_LD -Qunused-arguments  -c $tc -o test.o $4 > out 2>&1
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail
+@@ -2208,8 +2208,8 @@
+ $as_echo_n "checking \"$1\"... " >&6; }
+ 	echo "### $1" >> $charmout
+ 	cat $t >> $charmout
+-	echo $CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -c $t -o test.o $4 >> $charmout
+-	$CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -c $t -o test.o $4 > out 2>&1
++	echo $CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -Qunused-arguments -c $t -o test.o $4 >> $charmout
++	$CMK_CXX -I../include -I. $CMK_LIBDIR $CMK_INCDIR $CMK_SYSINC $OPTS_CXX $OPTS_LD -Qunused-arguments -c $t -o test.o $4 > out 2>&1
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/fj.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/fj.patch
@@ -1,0 +1,61 @@
+diff --git a/src/arch/netlrts-linux-arm8/cc-fcc.h b/src/arch/netlrts-linux-arm8/cc-fcc.h
+new file mode 100644
+index 000000000..f25b2250a
+--- /dev/null
++++ b/src/arch/netlrts-linux-arm8/cc-fcc.h
+@@ -0,0 +1,6 @@
++#undef CMK_DLL_CC
++
++#undef  CMK_COMPILEMODE_ORIG
++#undef  CMK_COMPILEMODE_ANSI
++#define CMK_COMPILEMODE_ORIG                               1
++#define CMK_COMPILEMODE_ANSI                               0
+diff --git a/src/arch/netlrts-linux-arm8/cc-fcc.sh b/src/arch/netlrts-linux-arm8/cc-fcc.sh
+new file mode 100644
+index 000000000..0efdc417e
+--- /dev/null
++++ b/src/arch/netlrts-linux-arm8/cc-fcc.sh
+@@ -0,0 +1,15 @@
++# Assumes Fujitsu C/C++ compiler:
++CMK_CPP_CHARM="cpp -P"
++CMK_CPP_C="fcc$CMK_COMPILER_SUFFIX"
++CMK_CC="fcc$CMK_COMPILER_SUFFIX"
++CMK_LD="fcc$CMK_COMPILER_SUFFIX"
++CMK_CXX="FCC$CMK_COMPILER_SUFFIX"
++CMK_LDXX="FCC$CMK_COMPILER_SUFFIX"
++
++CMK_CPP_C_FLAGS="-E"
++
++CMK_PIC='' # empty string: will be reset to default by conv-config.sh
++CMK_PIE='-fPIE'
++
++CMK_COMPILER='fcc'
++CMK_WARNINGS_ARE_ERRORS="-Werror"
+diff --git a/src/arch/netlrts-linux-arm8/conv-mach-frt.h b/src/arch/netlrts-linux-arm8/conv-mach-frt.h
+new file mode 100644
+index 000000000..d1ab56ad5
+--- /dev/null
++++ b/src/arch/netlrts-linux-arm8/conv-mach-frt.h
+@@ -0,0 +1 @@
++/* This file intentionally left blank */
+diff --git a/src/arch/netlrts-linux-arm8/conv-mach-frt.sh b/src/arch/netlrts-linux-arm8/conv-mach-frt.sh
+new file mode 100644
+index 000000000..1de93a5ed
+--- /dev/null
++++ b/src/arch/netlrts-linux-arm8/conv-mach-frt.sh
+@@ -0,0 +1,15 @@
++CMK_CF90="frt"
++
++CMK_FPP="$CMK_CF90 -Ccpp"
++
++CMK_CF90_FIXED="$CMK_CF90 -Fixed "
++
++CMK_F90LIBS="-lfj90i -lfj90f -lfjsrcinfo -lfjsrcinfo -lelf"
++
++CMK_CF77=$CMK_CF90
++CMK_F77LIBS=$CMK_F90LIBS
++
++CMK_MOD_NAME_ALLCAPS=
++CMK_MOD_EXT="mod"
++CMK_F90_USE_MODDIR=1
++CMK_F90_MODINC="-I"

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/mpi.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/mpi.patch
@@ -1,0 +1,19 @@
+--- old/src/scripts/configure
++++ new/src/scripts/configure
+@@ -3293,10 +3293,16 @@
+         test_link "whether -lmpi" "ok" "no" "-lmpi"
+         if test $pass -eq 1
+         then
+                 add_flag CMK_SYSLIBS='"$CMK_SYSLIBS -lmpi"' "mpi lib"
+         else
++          test_link "whether -lmpi -lmpi_cxx" "ok" "no" "-lmpi -lmpi_cxx"
++          if test $pass -eq 1
++          then
++            add_flag CMK_SYSLIBS='"$CMK_SYSLIBS -lmpi -lmpi_cxx"' "mpi lib"
++          else
+                 echo "Error: can not find mpi library"
+                 test_finish 1
++          fi
+         fi
+       fi
+     else

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/nvhpc.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/nvhpc.patch
@@ -1,0 +1,77 @@
+--- /dev/null	2020-08-25 10:23:08.110000124 -0700
++++ b/src/arch/common/cc-nvc.h	2020-09-03 08:11:13.912665728 -0700
+@@ -0,0 +1,9 @@
++#undef CMK_DLL_CC
++
++/* pgcc can not compile RDTSC timer */
++#if CMK_TIMER_USE_RDTSC
++# undef CMK_TIMER_USE_GETRUSAGE
++# undef CMK_TIMER_USE_RDTSC
++# define CMK_TIMER_USE_GETRUSAGE                            1
++# define CMK_TIMER_USE_RDTSC                                0
++#endif
+--- /dev/null	2020-08-25 10:23:08.110000124 -0700
++++ b/src/arch/common/cc-nvc.sh	2020-09-03 08:11:01.439597250 -0700
+@@ -0,0 +1,42 @@
++
++# machine specific recommendation
++CMK_DEFS=""
++case `hostname` in
++*.ranger.tacc.utexas.edu) CMK_DEFS="-tp barcelona-64 " ;;
++esac
++
++CMK_CPP_C="nvc -E "
++CMK_CC="nvc -fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 "
++CMK_CC_RELIABLE="gcc "
++CMK_CXX="nvc++ -fPIC -DCMK_FIND_FIRST_OF_PREDICATE=1 --no_using_std "
++CMK_LD="$CMK_CC "
++CMK_LDXX="$CMK_CXX "
++CMK_PIE=" "
++
++# compiler for compiling sequential programs
++# nvc can not handle QT right for generic64, so always use gcc
++CMK_SEQ_CC="gcc -fPIC "
++CMK_SEQ_LD="$CMK_SEQ_CC "
++CMK_SEQ_CXX="nvc++ -fPIC --no_using_std "
++CMK_SEQ_LDXX="$CMK_SEQ_CXX"
++CMK_SEQ_LIBS=""
++
++# compiler for native programs
++CMK_NATIVE_CC="gcc "
++CMK_NATIVE_LD="gcc "
++CMK_NATIVE_CXX="g++ "
++CMK_NATIVE_LDXX="g++ "
++CMK_NATIVE_LIBS=""
++
++# fortran compiler
++CMK_CF77="nvfortran "
++CMK_CF90="nvfortran "
++CMK_CF90_FIXED="$CMK_CF90 -Mfixed "
++f90libdir="."
++f90bindir=`which nvfortran 2>/dev/null`
++if test -n "$f90bindir"
++then
++  f90libdir="$f90bindir/../lib"
++fi
++CMK_F90LIBS="-L$f90libdir "
++CMK_F90_USE_MODDIR=""
+--- /dev/null	2020-08-25 10:23:08.110000124 -0700
++++ b/src/arch/common/conv-mach-nvfortran.sh	2020-09-03 08:25:09.042243776 -0700
+@@ -0,0 +1,13 @@
++COMMENT="Use nvfortran fortran compiler"
++NVFORTRAN=`which nvfortran`
++if test x$NVFORTRAN = x
++then
++  echo charmc> Fatal error: nvfortran not found!
++  exit 1
++fi
++CMK_CF77="$NVFORTRAN "
++CMK_CF90="$NVFORTRAN "
++CMK_CF90_FIXED="$CMK_CF90 -Mfixed "
++CMK_F90LIBS="-lm "
++CMK_F90_MODINC="-module "
++CMK_F90_USE_MODDIR=""
+--- /dev/null   2020-08-25 10:23:08.110000124 -0700
++++ b/src/arch/common/conv-mach-nvfortran.h	2020-09-03 08:25:09.042243776 -0700
+@@ -0,0 +1,1 @@
++/* empty file */

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/ofi-crayshasta-arm.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/ofi-crayshasta-arm.patch
@@ -1,0 +1,13 @@
+diff --git a/src/arch/ofi-crayshasta/conv-mach.h b/src/arch/ofi-crayshasta/conv-mach.h
+index 61d295df3..9e15fd2a9 100644
+--- a/src/arch/ofi-crayshasta/conv-mach.h
++++ b/src/arch/ofi-crayshasta/conv-mach.h
+@@ -74,7 +74,7 @@
+ #define CMK_LBDB_ON					   1
+ 
+ #define CMK_64BIT                      1
+-#define CMK_AMD64                      1
++#define CMK_ARM                        1
+ 
+ /* Other possible definitions:
+ 

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/ofi-linux-arm8.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/ofi-linux-arm8.patch
@@ -1,0 +1,294 @@
+diff --git a/src/arch/common/conv-mach-craype.sh b/src/arch/common/conv-mach-craype.sh
+index b30eba6560..01055d4562 100644
+--- a/src/arch/common/conv-mach-craype.sh
++++ b/src/arch/common/conv-mach-craype.sh
+@@ -1,3 +1,6 @@
++CMK_BUILD_CRAY=1
++
++CMK_CRAY_NOGNI=1
+ 
+ PGCC=`CC -V 2>&1 | grep pgCC`
+ ICPC=`CC -V 2>&1 | grep Intel`
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-cxi.h b/src/arch/ofi-linux-arm8/conv-mach-cxi.h
+new file mode 100644
+index 0000000000..8267a8fdb8
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-cxi.h
+@@ -0,0 +1,94 @@
++#ifndef _CONV_MACH_H
++#define _CONV_MACH_H
++
++#define CMK_OFI                                            1
++/* for Slingshot-11 the provider is CXI, this is notably different
++ in how memory registration is handled from the old OFI. */
++#ifdef CMK_CXI
++#undef CMK_CXI
++#endif
++#define CMK_CXI                                        1
++
++/* define the default linker, together with its options */
++#define CMK_DLL_CC   "g++ -shared -O3 -o "
++
++/* 1 if the machine has a function called "getpagesize()", 0 otherwise .
++   used in the memory files of converse */
++#define CMK_GETPAGESIZE_AVAILABLE                          1
++
++/* defines which version of memory handlers should be used.
++   used in conv-core/machine.C */
++#define CMK_MALLOC_USE_GNU_MALLOC                          0
++#define CMK_MALLOC_USE_OS_BUILTIN                          1
++
++#define CMK_MEMORY_PAGESIZE                                4096
++#define CMK_MEMORY_PROTECTABLE                             1
++
++/* the following definitions set the type of shared variables to be used. only
++   one of them must be 1, all the others 0. The different implementations are in
++   converse.h. Typically used are UNAVAILABLE for non SMP versions and
++   POSIX_THREADS_SMP for SMP versions. The others are used only in special
++   cases: NT_THREADS for Windows. */
++#define CMK_SHARED_VARS_UNAVAILABLE                        1 /* non SMP versions */
++#define CMK_SHARED_VARS_POSIX_THREADS_SMP                  0 /* SMP versions */
++#define CMK_SHARED_VARS_NT_THREADS                         0
++
++/* the following define if signal handlers should be used, both equal to zero
++   means that signals will not be used. only one of the following can be 1, the
++   other must be 0. they differ in the fact that the second (_WITH_RESTART)
++   enables retry on interrupt (a function is recalled upon interrupt and does
++   not return EINTR as in the first case) */
++#define CMK_SIGNAL_USE_SIGACTION                           0
++#define CMK_SIGNAL_USE_SIGACTION_WITH_RESTART              1
++
++/* specifies whether the CthCpv variables should be defined as Cpv (0) or
++   directly as normal c variables (1) */
++#define CMK_THREADS_REQUIRE_NO_CPV                         0
++
++/* decide which is the default implementation of the threads (see threads.C)
++   Only one of the following can be 1. If none of them is selected, qthreads
++   will be used as default. This default can be overwritten at compile time
++   using -DCMK_THREADS_BUILD_"type"=1 */
++#define CMK_THREADS_USE_CONTEXT                            0
++#define CMK_THREADS_USE_FCONTEXT                           1
++#define CMK_THREADS_USE_JCONTEXT                           0
++#define CMK_THREADS_USE_PTHREADS                           0
++
++/* Specifies what kind of timer to use, and the correspondent headers will be
++   included in convcore.C. If none is selected, then the machine.C file needs to
++   implement the timer primitives. */
++#define CMK_TIMER_USE_RTC                                  0
++#define CMK_TIMER_USE_RDTSC                                0
++#define CMK_TIMER_USE_GETRUSAGE                            1
++#define CMK_TIMER_USE_SPECIAL                              0
++#define CMK_TIMER_USE_TIMES                                0
++
++/* Specifies what the processor will do when it is idle, either sleep (1) or go
++   into busy waiting mode (0). In convcore.C there are a few files included if
++   sleeping mode, but the real distinct implementation is in the machine.C
++   file. */
++#define CMK_WHEN_PROCESSOR_IDLE_USLEEP                     0
++
++/* specifies whether there is a web server collecting utilization statistics (1)
++   or not (0) */
++#define CMK_WEB_MODE                                       1
++
++#define CMK_DEBUG_MODE                                     0
++
++/* enables the load balancer framework. set to 1 for almost all the machines */
++#define CMK_LBDB_ON					   1
++
++#define CMK_64BIT                      1
++#define CMK_AMD64                      1
++
++/* Other possible definitions:
++
++In fault tolerant architectures, CK_MEM_CHECKPOINT can be set. In this case the
++extended header must contain also another field called "pn" (phase number).
++
++*/
++
++/* Use PMI2 by default on Cray systems with cray-pmi */
++#include "conv-mach-slurmpmi2cray.h"
++
++#endif
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-cxi.sh b/src/arch/ofi-linux-arm8/conv-mach-cxi.sh
+new file mode 100644
+index 0000000000..df5c695ba6
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-cxi.sh
+@@ -0,0 +1,27 @@
++
++
++# For libfabric If the user doesn't pass --basedir, use pkg-config for
++#libfabric headers and library to avoid some linker wackiness, we
++#order them: pal libs, PMI libs, lib64.  So that if someplace (i.e.,
++#NCSA) puts regular pmi libs in /usr/lib64, we get them from the
++#package's cray-pmi dir not their unextended pmi.  libpals comes along
++#for the ride here due to a dependency in pmi.  fabric can just go
++#after the others.
++
++
++if test -z "$USER_OPTS_LD"
++then
++    module load cray-pmi libfabric
++    CMK_LIBFABRIC_INC=`pkg-config --cflags libfabric`
++    CMK_LIBFABRIC_LIBS=`pkg-config --libs libfabric`
++    CMK_LIBPALS_LIBS=""
++    CMK_LIBPALS_LDPAT=""
++    CMK_PMI_INC=`pkg-config --cflags cray-pmi`
++    CMK_PMI_LIBS=`pkg-config --libs cray-pmi`
++    CMK_LIBPMI_LDPATH=`pkg-config cray-pmi --variable=libdir`
++    CMK_INCDIR="$CMK_PMI_INC -I/usr/include/slurm/ $CMK_LIBFABRIC_INC $CMK_INCDIR "
++    CMK_LIBS="-Wl,-rpath,$CMK_LIBPALS_LDPATH,-rpath,$CMK_LIBPMI_LDPATH $CMK_LIBPALS_LIBS $CMK_PMI_LIBS -L/usr/lib64/ $CMK_LIBFABRIC_LIBS $CMK_LIBS "
++fi
++
++# For runtime
++CMK_INCDIR="$CMK_INCDIR -I./proc_management/"
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-pthreads.h b/src/arch/ofi-linux-arm8/conv-mach-pthreads.h
+new file mode 100644
+index 0000000000..94e01fd177
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-pthreads.h
+@@ -0,0 +1,10 @@
++
++#undef CMK_MALLOC_USE_GNU_MALLOC
++#undef CMK_MALLOC_USE_OS_BUILTIN
++#undef CMK_MALLOC_USE_GNUOLD_MALLOC
++#define CMK_MALLOC_USE_OS_BUILTIN                          1
++                                                                                
++#undef CMK_THREADS_USE_CONTEXT
++#undef CMK_THREADS_USE_PTHREADS
++#define CMK_THREADS_USE_PTHREADS                           1
++
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-pthreads.sh b/src/arch/ofi-linux-arm8/conv-mach-pthreads.sh
+new file mode 100644
+index 0000000000..34cb4c68cf
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-pthreads.sh
+@@ -0,0 +1,2 @@
++
++CMK_LIBS="$CMK_LIBS -lpthread "
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-smp.h b/src/arch/ofi-linux-arm8/conv-mach-smp.h
+new file mode 100644
+index 0000000000..5e89297ba1
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-smp.h
+@@ -0,0 +1,20 @@
++
++#define CMK_SMP						   1
++
++
++#undef CMK_SHARED_VARS_UNAVAILABLE
++#undef CMK_SHARED_VARS_POSIX_THREADS_SMP
++#define CMK_SHARED_VARS_UNAVAILABLE                        0
++#define CMK_SHARED_VARS_POSIX_THREADS_SMP                  1
++
++#undef CMK_MALLOC_USE_GNU_MALLOC
++#undef CMK_MALLOC_USE_OS_BUILTIN
++#define CMK_MALLOC_USE_GNU_MALLOC                          0
++#define CMK_MALLOC_USE_OS_BUILTIN                          1
++
++/*#define CMK_MMAP_PROBE                                     1 */
++
++/*#define CMK_PCQUEUE_LOCK				   1 */
++/*#define CMK_USE_MFENCE 					   1 */
++/* Replaced by CMK_NOT_USE_TLS_THREAD as default */
++/*#define CMK_USE_TLS_THREAD                                 1*/
+diff --git a/src/arch/ofi-linux-arm8/conv-mach-smp.sh b/src/arch/ofi-linux-arm8/conv-mach-smp.sh
+new file mode 100644
+index 0000000000..ce625d65e9
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach-smp.sh
+@@ -0,0 +1,3 @@
++CMK_DEFS="$CMK_DEFS -D_REENTRANT"
++CMK_LIBS="-lpthread $CMK_LIBS "
++CMK_SMP='1'
+diff --git a/src/arch/ofi-linux-arm8/conv-mach.h b/src/arch/ofi-linux-arm8/conv-mach.h
+new file mode 100644
+index 0000000000..ec4b7bb384
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach.h
+@@ -0,0 +1,63 @@
++
++#ifndef _CONV_MACH_H
++#define _CONV_MACH_H
++
++#define CMK_NETPOLL         1
++
++#define CMK_ARM					  1 
++#define CMK_OFI 1
++#define CMK_ASYNC_NOT_NEEDED                               0
++#define CMK_ASYNC_USE_FIOASYNC_AND_FIOSETOWN               0
++#define CMK_ASYNC_USE_FIOASYNC_AND_SIOCSPGRP               0
++#define CMK_ASYNC_USE_FIOSSAIOSTAT_AND_FIOSSAIOOWN         0
++#define CMK_ASYNC_USE_F_SETFL_AND_F_SETOWN                 1
++
++#define CMK_DLL_CC  "g++ -shared -O3 -o "
++
++#define CMK_GETPAGESIZE_AVAILABLE                          1
++
++#define CMK_MALLOC_USE_GNU_MALLOC                          0
++#define CMK_MALLOC_USE_OS_BUILTIN                          1
++
++#define CMK_MEMORY_PAGESIZE                                4096
++#define CMK_MEMORY_PROTECTABLE                             0
++
++
++#define CMK_SSH_IS_A_COMMAND                               1
++#define CMK_SSH_NOT_NEEDED                                 0
++
++#define CMK_SHARED_VARS_UNAVAILABLE                        1
++
++#define CMK_THREADS_USE_CONTEXT                            1
++#define CMK_THREADS_USE_JCONTEXT                           0
++#define CMK_THREADS_USE_FCONTEXT                           0
++#define CMK_THREADS_USE_PTHREADS                           0
++#define CMK_THREADS_ARE_WIN32_FIBERS                       0
++
++#define CMK_SIGNAL_NOT_NEEDED                              0
++#define CMK_SIGNAL_USE_SIGACTION                           0
++#define CMK_SIGNAL_USE_SIGACTION_WITH_RESTART              1
++
++#define CMK_THREADS_REQUIRE_NO_CPV                         0
++#define CMK_THREADS_COPY_STACK                             0
++
++#define CMK_TIMER_USE_RDTSC                                0
++#define CMK_TIMER_USE_GETRUSAGE                            1
++#define CMK_TIMER_USE_SPECIAL                              0
++#define CMK_TIMER_USE_TIMES                                0
++
++#define CMK_64BIT   1 
++#define CMK_32BIT   0
++#define CMK_WHEN_PROCESSOR_IDLE_BUSYWAIT                   0
++#define CMK_WHEN_PROCESSOR_IDLE_USLEEP                     1
++
++
++#define CMK_DEBUG_MODE					   0 
++#define CMK_WEB_MODE                                       1
++
++#define CMK_LBDB_ON					   1
++
++
++#endif
++
++
+diff --git a/src/arch/ofi-linux-arm8/conv-mach.sh b/src/arch/ofi-linux-arm8/conv-mach.sh
+new file mode 100644
+index 0000000000..eb3bcc4358
+--- /dev/null
++++ b/src/arch/ofi-linux-arm8/conv-mach.sh
+@@ -0,0 +1,16 @@
++. $CHARMINC/cc-gcc.sh
++
++# For libfabric
++#If the user doesn't pass --basedir, use defaults for libfabric headers and library
++if test -z "$USER_OPTS_LD"
++then
++    CMK_INCDIR="-I/usr/include/"
++#    CMK_LIBDIR="-L/usr/lib64/"
++fi
++
++CMK_LIBS="$CMK_LIBS -lfabric"
++
++# For runtime
++CMK_INCDIR="$CMK_INCDIR -I./proc_management/ -I./proc_management/simple_pmi/"
++
++CMK_QT='generic64-light'

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/package.py
@@ -1,0 +1,468 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import os
+import platform
+import shutil
+import sys
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+# 1. Fix patch for crayshasta
+# 2. Set arch for linux rather than crayshasta
+# 3. Add slurmpmi2cray for cray-pmi
+
+class Charmpp(Package):
+    """Charm++ is a parallel programming framework in C++ supported by
+    an adaptive runtime system, which enhances user productivity and
+    allows programs to run portably from small multicore computers
+    (your laptop) to the largest supercomputers."""
+
+    homepage = "https://charmplusplus.org"
+    url = "https://charm.cs.illinois.edu/distrib/charm-6.8.2.tar.gz"
+    git = "https://github.com/UIUC-PPL/charm.git"
+
+    maintainers("matthiasdiener")
+
+    version("main", branch="main")
+
+    version(
+        "8.0.0",
+        sha256="e30fc1e921e5cbf3406e792d5b0ca5f211c5d8ffbfc56e56d5501d8118abcaf6",
+        url="https://github.com/charmplusplus/charm/archive/refs/tags/v8.0.0.tar.gz",
+    )
+    version("7.0.0", sha256="9c247b421bb157bdf9bc0ced3e25738c7a1dc1f7ec57b7943a7faf97f7e4fb2e")
+    version("6.10.2", sha256="7abb4cace8aebdfbb8006eac03eb766897c009cfb919da0d0a33f74c3b4e6deb")
+    version("6.10.1", sha256="ab96198105daabbb8c8bdf370f87b0523521ce502c656cb6cd5b89f69a2c70a8")
+    version("6.10.0", sha256="7c526a78aa0c202b7f0418b345138e7dc40496f0bb7b9e301e0381980450b25c")
+    version("6.9.0", sha256="85ed660e46eeb7a6fc6b32deab08226f647c244241948f6b592ebcd2b6050cbd")
+    version("6.8.2", sha256="08e6001b0e9cd00ebde179f76098767149bf7e454f29028fb9a8bfb55778698e")
+    version("6.8.1", sha256="bf39666bb9f8bad1cd17dafa3cdf35c7ef64dfaeda835cf66ae530b7baab7583")
+    version("6.8.0", sha256="deca68622932ea0c677aa764d6d24cd169a2fd99c06e7d7b6947c0f18ec2f8f3")
+    version("6.7.1", sha256="744a093874fbac03b6ae8be3ce434eff46b2ee778561e860802ed578e0810fdf")
+    version("6.7.0", sha256="6b0d8215a180c90cf6ee33ff39f66726934df34aaeeed59650dd3a0cc54d0c87")
+    version("6.6.1", sha256="2aa16fd3015dce0a0932ab5253578a72ddbcb889bc0d23584c42b28446915467")
+    version("6.6.0", sha256="c916010f2d4cc2c6bd30ea19764839d0298fb56d1696d8ff08d9fa9a61dfb1c9")
+    version("6.5.1", sha256="68aa43e2a6e476e116a7e80e385c25c6ac6497807348025505ba8bfa256ed34a")
+
+    # Support OpenMPI; see
+    # <https://github.com/UIUC-PPL/charm/issues/1206>
+    # Patch is no longer needed in versions 6.8.0+
+    patch("mpi.patch", when="@:6.7.1")
+
+    # Patch for AOCC
+    patch("charm_6.7.1_aocc.patch", when="@6.7.1 %aocc", level=1)
+    patch("charm_6.8.2_aocc.patch", when="@6.8.2 %aocc", level=3)
+
+    # support Fujitsu compiler
+    patch("fj.patch", when="%fj")
+
+    # support NVIDIA compilers
+    patch("nvhpc.patch", when="%nvhpc")
+
+    # Ignore compiler warnings while configuring
+    patch("strictpass.patch", when="@:6.8.2")
+
+    # Support Cray Shasta with ARM
+    patch("ofi-crayshasta-arm.patch", when="@7 backend=ofi pmi=cray-pmi target=aarch64:")
+    
+    # Patch to support arm on Linux with OFI
+    patch("ofi-linux-arm8.patch", when="@8: backend=ofi pmi=cray-pmi target=aarch64:")
+    
+    # Modify modules used.
+    def patch(self):
+        filter_file(
+            "module load cray-libpals",
+            'module load',
+            "src/arch/ofi-linux-x86_64/conv-mach-cxi.sh",
+        )
+
+
+    # Build targets
+    # "target" is reserved, so we have to use something else.
+    variant(
+        "build-target",
+        default="LIBS",
+        # AMPI also builds charm++, LIBS also builds AMPI and charm++
+        values=("charm++", "AMPI", "LIBS", "ChaNGa"),
+        description="Specify the target to build",
+    )
+
+    # Communication mechanisms (choose exactly one)
+    # - Default to 'multicore' on macOS because that's probably the right choice
+    #   for a personal machine.
+    if sys.platform == "darwin":
+        backend_default = "multicore"
+    else:
+        backend_default = "netlrts"
+    variant(
+        "backend",
+        default=backend_default,
+        values=("mpi", "multicore", "netlrts", "verbs", "gni", "ucx", "ofi", "pami", "pamilrts"),
+        description="Set the backend to use",
+    )
+
+    # Process management interface
+    variant(
+        "pmi",
+        default="none",
+        values=("none", "simplepmi", "slurmpmi", "slurmpmi2", "pmix", "cray-pmi"),
+        description="The ucx/ofi/gni backends need PMI to run!",
+    )
+
+    # Other options
+    variant("papi", default=False, description="Enable PAPI integration")
+    variant("syncft", default=False, description="Compile with Charm++ fault tolerance support")
+    variant("smp", default=True, description="Enable SMP parallelism")
+    variant("tcp", default=False, description="Use TCP as transport mechanism (requires +net)")
+    variant("omp", default=False, description="Support for the integrated LLVM OpenMP runtime")
+    variant("pthreads", default=False, description="Compile with pthreads Converse threads")
+    variant("cuda", default=False, description="Enable CUDA toolkit")
+
+    variant("shared", default=True, description="Enable shared link support")
+    variant("production", default=True, description="Build charm++ with all optimizations")
+    variant("tracing", default=False, description="Enable tracing modules")
+
+    # Applies only to versions 8.0.0 and later
+    variant(
+        "fortran", default=True, description="Enable Fortran support (false applies only to @8:)"
+    )
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build", when="+fortran")
+    # Fortran is required for version earlier than 8.0.0
+    conflicts("~fortran", when="@:7")
+    # charmpp build was failing with clang based compilers for -DNETWORK=mpi as discussed in
+    # https://github.com/charmplusplus/charm/issues/3645
+    # Fix was suggested in https://github.com/charmplusplus/charm/pull/3646 and the same has
+    # been implemented in v8.0.0
+    conflicts("%fortran=intel-oneapi-compilers", when="@8: +fortran")
+    conflicts("%fortran=aocc", when="@8: +fortran")
+
+    # Versions 7.0.0+ use CMake by default when it's available. It's more
+    # robust.
+    depends_on("cmake@3.4:", when="@7.0.0:", type="build")
+
+    depends_on("mpi", when="backend=mpi")
+    depends_on("papi", when="+papi")
+    depends_on("cuda", when="+cuda")
+
+    depends_on("ucx", when="backend=ucx")
+    depends_on("libfabric", when="backend=ofi")
+    depends_on("slurm@:17-11-9-2", when="pmi=slurmpmi")
+    depends_on("slurm@17-11-9-2:", when="pmi=slurmpmi2")
+
+    # FIXME : As of now spack's OpenMPI recipe does not have a PMIx variant
+    # But if users have external installs of OpenMPI with PMIx support, this
+    # will allow them to build charm++ with it.
+    depends_on("openmpi", when="pmi=pmix")
+
+    depends_on("mpi", when="pmi=simplepmi")
+    depends_on("mpi", when="pmi=slurmpmi")
+    depends_on("mpi", when="pmi=slurmpmi2")
+    depends_on("cray-mpich", when="pmi=cray-pmi")
+
+    # Git versions of Charm++ require automake and autoconf
+    depends_on("automake", when="@develop")
+    depends_on("autoconf", when="@develop")
+    depends_on("gmake", type="build")
+
+    conflicts("~tracing", "+papi")
+
+    conflicts("backend=multicore", when="~smp", msg="The 'multicore' backend always uses SMP")
+    conflicts("backend=ucx", when="@:6.9")
+
+    # Shared-lib builds with GCC are broken on macOS:
+    # https://github.com/UIUC-PPL/charm/issues/3181
+    conflicts("+shared", when="platform=darwin %gcc")
+
+    # Charm++ versions below 7.0.0 have build issues on macOS, mainly due to the
+    # pre-7.0.0 `VERSION` file conflicting with other version files on the
+    # system: https://github.com/UIUC-PPL/charm/issues/2844. Specifically, it
+    # conflicts with LLVM's `<version>` header that was added in llvm@7.0.0 to
+    # comply with the C++20 standard:
+    # https://en.cppreference.com/w/cpp/header/version. The conflict only occurs
+    # on case-insensitive file systems, as typically used on macOS machines.
+    conflicts("@:6", when="platform=darwin %apple-clang@7:")
+    conflicts("@:6", when="platform=darwin %clang@7:")
+
+    @property
+    def charmarch(self):
+        plat = sys.platform
+
+        if plat.startswith("linux"):
+            plat = "linux"
+        elif plat.startswith("win"):
+            plat = "win"
+        elif plat.startswith("cnl"):
+            plat = "cnl"
+        elif plat.startswith("cnk"):
+            plat = "cnk"
+
+        mach = platform.machine()
+
+        if mach.startswith("ppc"):
+            mach = "ppc"
+        elif mach.startswith("arm"):
+            mach = "arm"
+
+        comm = self.spec.variants["backend"].value
+
+        # Define Charm++ version names for various (plat, mach, comm)
+        # combinations. Note that not all combinations are supported.
+        versions = {
+            ("darwin", "x86_64", "mpi"): "mpi-darwin-x86_64",
+            ("darwin", "x86_64", "multicore"): "multicore-darwin-x86_64",
+            ("darwin", "x86_64", "netlrts"): "netlrts-darwin-x86_64",
+            ("linux", "x86_64", "mpi"): "mpi-linux-x86_64",
+            ("linux", "x86_64", "multicore"): "multicore-linux-x86_64",
+            ("linux", "x86_64", "netlrts"): "netlrts-linux-x86_64",
+            ("linux", "x86_64", "verbs"): "verbs-linux-x86_64",
+            ("linux", "x86_64", "ofi"): "ofi-linux-x86_64",
+            ("linux", "ppc", "mpi"): "mpi-linux-ppc",
+            ("linux", "ppc", "multicore"): "multicore-linux-ppc",
+            ("linux", "ppc", "netlrts"): "netlrts-linux-ppc",
+            ("linux", "ppc", "pami"): "pami-linux-ppc64le",
+            ("linux", "ppc", "verbs"): "verbs-linux-ppc64le",
+            ("linux", "arm", "netlrts"): "netlrts-linux-arm7",
+            ("linux", "aarch64", "netlrts"): "netlrts-linux-arm8",
+            ("win", "x86_64", "mpi"): "mpi-win-x86_64",
+            ("win", "x86_64", "multicore"): "multicore-win-x86_64",
+            ("win", "x86_64", "netlrts"): "netlrts-win-x86_64",
+            ("cnl", "x86_64", "gni"): "gni-crayxc",
+            ("cnl", "x86_64", "mpi"): "mpi-crayxc",
+        }
+
+        if self.spec.satisfies("@6.10:"):
+            versions.update(
+                {
+                    ("linux", "x86_64", "ucx"): "ucx-linux-x86_64",
+                    ("linux", "aarch64", "ucx"): "ucx-linux-arm8",
+                }
+            )
+
+        # Some versions were renamed/removed in 6.11
+        if self.spec.version < Version("6.11.0"):
+            versions.update(
+                {
+                    ("linux", "i386", "mpi"): "mpi-linux",
+                    ("linux", "i386", "multicore"): "multicore-linux",
+                    ("linux", "i386", "netlrts"): "netlrts-linux",
+                    ("linux", "i386", "uth"): "uth-linux",
+                    ("linux", "arm", "multicore"): "multicore-arm7",
+                    ("linux", "aarch64", "multicore"): "multicore-arm8",
+                }
+            )
+        else:
+            versions.update(
+                {
+                    ("linux", "i386", "mpi"): "mpi-linux-i386",
+                    ("linux", "i386", "multicore"): "multicore-linux-i386",
+                    ("linux", "i386", "netlrts"): "netlrts-linux-i386",
+                    ("linux", "arm", "multicore"): "multicore-linux-arm7",
+                    ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
+                }
+            )
+
+        if self.spec.satisfies("@7:"):
+            versions.update(
+                {
+                    ("linux", "arm", "mpi"): "mpi-linux-arm7",
+                    ("linux", "aarch64", "mpi"): "mpi-linux-arm8",
+                    ("darwin", "arm", "multicore"): "multicore-darwin-arm8",
+                    ("darwin", "arm", "netlrts"): "netlrts-darwin-arm8",
+                    ("darwin", "arm", "mpi"): "mpi-darwin-arm8",
+                }
+            )
+
+            if self.spec.satisfies("backend=ofi pmi=cray-pmi"):
+                versions.update(
+                    {
+                        ("linux", "x86_64", "ofi"): "ofi-linux-x86_64",
+                        ("linux", "aarch64", "ofi"): "ofi-linux-arm8",
+                    }
+                )
+
+        if (plat, mach, comm) not in versions:
+            raise InstallError(
+                "The communication mechanism %s is not supported "
+                "on a %s platform with a %s CPU" % (comm, plat, mach)
+            )
+
+        return versions[(plat, mach, comm)]
+
+    # FIXME: backend=mpi also provides mpi, but spack does not support
+    # depends_on("mpi") and provides("mpi") in the same package currently.
+    # for b in ['multicore', 'netlrts', 'verbs', 'gni', 'ofi', 'pami',
+    #          'pamilrts']:
+    #    provides('mpi@2', when='@6.7.1:
+    #            build-target=AMPI backend={0}'.format(b))
+    #    provides('mpi@2', when='@6.7.1:
+    #            build-target=LIBS backend={0}'.format(b))
+
+    def install(self, spec, prefix):
+        if "backend=mpi" not in self.spec or "backend=netlrts" not in self.spec:
+            if self.spec.satisfies("+pthreads"):
+                raise InstallError(
+                    "The pthreads option is only available on the Netlrts and MPI network layers."
+                )
+
+        if (
+            ("backend=ucx" in self.spec)
+            or ("backend=ofi" in self.spec)
+            or ("backend=gni" in self.spec)
+        ):
+            if self.spec.satisfies("pmi=none"):
+                raise InstallError(
+                    "The UCX/OFI/GNI backends need PMI to run. Please add pmi=... "
+                    "Note that PMIx is the preferred option."
+                )
+
+        if (
+            ("pmi=simplepmi" in self.spec)
+            or ("pmi=slurmpmi" in self.spec)
+            or ("pmi=slurmpmi2" in self.spec)
+        ):
+            if self.spec.satisfies("^openmpi"):
+                raise InstallError(
+                    "To use any process management interface other than PMIx, "
+                    "a non OpenMPI based MPI must be present on the system"
+                )
+
+        target = spec.variants["build-target"].value
+        builddir = prefix
+
+        # We assume that Spack's compiler wrappers make this work. If
+        # not, then we need to query the compiler vendor from Spack
+        # here.
+        options = [os.path.basename(self.compiler.cc)]
+
+        if "@:6.8.2 %aocc" not in spec and spec.satisfies("+fortran"):
+            options.append(os.path.basename(self.compiler.fc))
+
+        options.append("-j%d" % make_jobs)
+        options.append("--destination=%s" % builddir)
+
+        if spec.satisfies("pmi=slurmpmi"):
+            options.append("slurmpmi")
+        if spec.satisfies("pmi=slurmpmi2"):
+            options.append("slurmpmi2")
+        if spec.satisfies("pmi=pmix"):
+            options.append("ompipmix")
+            options.extend(["--basedir=%s" % spec["openmpi"].prefix])
+        if spec.satisfies("pmi=cray-pmi"):
+            options.append("slurmpmi2cray")
+
+        if spec.satisfies("backend=mpi"):
+            # in intelmpi <prefix>/include and <prefix>/lib fails so --basedir
+            # cannot be used
+            options.extend(
+                ["--incdir={0}".format(incdir) for incdir in spec["mpi"].headers.directories]
+            )
+            options.extend(
+                ["--libdir={0}".format(libdir) for libdir in spec["mpi"].libs.directories]
+            )
+
+        if spec.satisfies("backend=ucx"):
+            options.extend(["--basedir=%s" % spec["ucx"].prefix])
+        if spec.satisfies("+papi"):
+            options.extend(["papi", "--basedir=%s" % spec["papi"].prefix])
+        if "+smp" in spec and "backend=multicore" not in spec:
+            # The 'multicore' backend always uses SMP, so we don't have to
+            # append the 'smp' option when the 'multicore' backend is active. As
+            # of Charm++ v7.0.0 it is actually a build error to append 'smp'
+            # with the 'multicore' backend.
+            options.append("smp")
+        if spec.satisfies("+tcp"):
+            if "backend=netlrts" not in spec:
+                # This is a Charm++ limitation; it would lead to a
+                # build error
+                raise InstallError(
+                    "The +tcp variant requires " "the backend=netlrts communication mechanism"
+                )
+            options.append("tcp")
+        if spec.satisfies("+omp"):
+            options.append("omp")
+        if spec.satisfies("+pthreads"):
+            options.append("pthreads")
+        if spec.satisfies("+cuda"):
+            options.append("cuda")
+
+        if spec.satisfies("+shared"):
+            options.append("--build-shared")
+        if spec.satisfies("+production"):
+            options.append("--with-production")
+        if spec.satisfies("+tracing"):
+            options.append("--enable-tracing")
+
+        if self.spec.satisfies("@8: ~fortran"):
+            options.append("--disable-fortran")
+
+        # Call "make" via the build script
+        # Note: This builds Charm++ in the "tmp" subdirectory of the
+        # install directory. Maybe we could set up a symbolic link
+        # back to the build tree to prevent this? Alternatively, we
+        # could dissect the build script; the build instructions say
+        # this wouldn't be difficult.
+        build = Executable(join_path(".", "build"))
+        build(target, self.charmarch, *options)
+
+        # Charm++'s install script does not copy files, it only creates
+        # symbolic links. Fix this.
+        for dirpath, dirnames, filenames in os.walk(builddir):
+            for filename in filenames:
+                filepath = join_path(dirpath, filename)
+                if os.path.islink(filepath):
+                    tmppath = filepath + ".tmp"
+                    # Skip dangling symbolic links
+                    try:
+                        copy(filepath, tmppath)
+                        os.remove(filepath)
+                        os.rename(tmppath, filepath)
+                    except OSError:
+                        pass
+
+        tmp_path = join_path(builddir, "tmp")
+        if not os.path.islink(tmp_path):
+            shutil.rmtree(tmp_path)
+
+        if self.spec.satisfies("@6.9.99"):
+            # A broken 'doc' link in the prefix can break the build.
+            # Remove it and replace it if it is broken.
+            try:
+                os.stat(prefix.doc)
+            except OSError:
+                os.remove(prefix.doc)
+                mkdirp(prefix.doc)
+
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
+    def check_build(self):
+        make(
+            "-C",
+            join_path(self.stage.source_path, "tests"),
+            "test",
+            "TESTOPTS=++local",
+            parallel=False,
+        )
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        if not self.spec.satisfies("backend=mpi"):
+            env.set("MPICC", self.prefix.bin.ampicc)
+            env.set("MPICXX", self.prefix.bin.ampicxx)
+            env.set("MPIF77", self.prefix.bin.ampif77)
+            env.set("MPIF90", self.prefix.bin.ampif90)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        self.spec.mpicc = self.prefix.bin.ampicc
+        self.spec.mpicxx = self.prefix.bin.ampicxx
+        self.spec.mpifc = self.prefix.bin.ampif90
+        self.spec.mpif77 = self.prefix.bin.ampif77
+        self.spec.charmarch = self.charmarch + "-smp" if self.spec.satisfies("+smp") else ""

--- a/repo/v1.0/spack_repo/isamrepo/packages/charmpp/strictpass.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/charmpp/strictpass.patch
@@ -1,0 +1,16 @@
+--- old/src/scripts/configure
++++ new/src/scripts/configure
+@@ -2146,13 +2146,6 @@
+ 	test_result $? "$1" "$2" "$3"
+  	strictpass=$pass
+ 	strictfail=$fail
+-        if test $pass -eq 1
+-	then
+- 	  if cat out | grep -i "warn" > /dev/null 2>&1
+-	  then
+-	    strictpass="0" && strictfail="1"
+-          fi
+-        fi
+ 	cat out >> $charmout
+ 	/bin/rm -f out
+ }

--- a/repo/v1.0/spack_repo/isamrepo/packages/cloverleaf_ref/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/cloverleaf_ref/package.py
@@ -1,0 +1,158 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class CloverleafRef(MakefilePackage):
+    """Proxy Application. CloverLeaf_ref is a miniapp that solves the
+    compressible Euler equations on a Cartesian grid,
+    using an explicit, second-order accurate method.
+    """
+
+    homepage = "https://github.com/UK-MAC/CloverLeaf_ref"
+    url = "https://github.com/UK-MAC/CloverLeaf_ref/archive/refs/tags/v1.3.tar.gz"
+    git = "https://github.com/green-br/CloverLeaf_ref.git"
+
+    maintainers("amd-toolchain-support")
+
+    version("master", branch="spack")
+
+    depends_on("c", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    variant(
+        "ieee", default=False, description="Build with IEEE754 compliant floating point operations"
+    )
+    variant("debug", default=False, description="Build with DEBUG flags")
+
+    depends_on("mpi")
+
+    parallel = False
+
+    # Cloverleaf_ref Makefile contains some but not all required options for each compiler.
+    # This package.py inserts what is needed for Intel, AOCC, and LLVM compilers.
+    @property
+    def build_targets(self):
+        targets = ["--directory=./"]
+
+        targets.append("MPI_COMPILER={0}".format(self.spec["mpi"].mpifc))
+        targets.append("C_MPI_COMPILER={0}".format(self.spec["mpi"].mpicc))
+
+        if self.spec.satisfies("+debug"):
+            targets.append("DEBUG=1")
+        if self.spec.satisfies("+ieee"):
+            targets.append("IEEE=1")
+
+        # Work around for bug in Makefiles for versions 1.3 and 1.1 (mis-defined as -openmp)
+        if self.spec.satisfies("%intel"):
+            targets.append("COMPILER=INTEL")
+            targets.append("OMP_INTEL=-qopenmp")
+
+        # Work around for missing AOCC compilers option in Makefiles for versions 1.3 and 1.1
+        elif self.spec.satisfies("%aocc"):
+            targets.append("COMPILER=AOCC")
+            targets.append("OMP_AOCC=-fopenmp")
+
+            if self.spec.satisfies("+ieee"):
+                targets.append("I3E_AOCC=-ffp-model=precise")
+                if self.spec.satisfies("%aocc@:4.0.0"):
+                    targets.append("I3E_AOCC+=-Kieee")
+
+            # logic for Debug build: no optimizatrion and debug symbols
+            if self.spec.satisfies("+debug"):
+                targets.append("FLAGS_AOCC=-O0 -g -Wall -Wextra -fsanitize=address")
+                targets.append("CFLAGS_AOCC=-O0 -g -Wall -Wextra -fsanitize=address")
+            else:
+                targets.append("CFLAGS_AOCC=-O3 -fnt-store=aggressive")
+                targets.append("FLAGS_AOCC=-O3 -fnt-store=aggressive")
+
+        # Work around for missing CLANG entries in Makefiles for master branch (commit:0fdb917),
+        # and for versions 1.3 and 1.1
+        elif self.spec.satisfies("%clang"):
+            targets.append("COMPILER=CLANG")
+            targets.append("OMP_CLANG=-fopenmp")
+
+            if self.spec.satisfies("+ieee"):
+                targets.append("I3E_CLANG=-ffp-model=precise")
+
+            # logic for Debug build: no optimizatrion and debug symbols
+            if self.spec.satisfies("+debug"):
+                targets.append("FLAGS_CLANG=-O0 -g")
+                targets.append("CFLAGS_CLANG=-O0 -g")
+            else:
+                targets.append("FLAGS_CLANG=-O3")
+                targets.append("CFLAGS_CLANG=-O3")
+
+        elif self.spec.satisfies("%gcc"):
+            targets.append("COMPILER=GNU")
+            if self.spec.satisfies("%gcc@10:"):
+                targets.append("FLAGS_GNU=-O3 -funroll-loops -fallow-argument-mismatch")
+                targets.append("CFLAGS_GNU=-O3 -funroll-loops")
+            else:
+                targets.append("FLAGS_GNU=-O3 -funroll-loops")
+                targets.append("CFLAGS_GNU=-O3 -funroll-loops")
+
+        elif self.spec.satisfies("%cce"):
+            if self.spec.satisfies("+ieee"):
+                targets.append("I3E_CRAY=")
+
+            targets.append("COMPILER=CRAY")
+            targets.append("OMP_CRAY=-fopenmp")
+            # logic for Debug build: no optimizatrion and debug symbols
+            if self.spec.satisfies("+debug"):
+                targets.append("FLAGS_CRAY=-O0 -g")
+                targets.append("CFLAGS_CRAY=-O0 -g")
+            else:
+                targets.append("FLAGS_CRAY=-O3")
+                targets.append("CFLAGS_CRAY=-O3")
+       
+        elif self.spec.satisfies("%nvhpc"):
+            if self.spec.satisfies("+ieee"):
+                targets.append("I3E_NVHPC=-Kieee")
+
+            targets.append("COMPILER=NVHPC")
+            targets.append("OMP_NVHPC=-mp")
+            # logic for Debug build: no optimizatrion and debug symbols
+            if self.spec.satisfies("+debug"):
+                targets.append("FLAGS_NVHPC=-O0 -g")
+                targets.append("CFLAGS_NVHPC=-O0 -g")
+            else:
+                targets.append("FLAGS_NVHPC=-O3")
+                targets.append("CFLAGS_NVHPC=-O3")
+        
+        elif self.spec.satisfies("%arm"):
+            if self.spec.satisfies("+ieee"):
+                targets.append("I3E_ARM=")
+
+            targets.append("COMPILER=ARM")
+            targets.append("OMP_ARM=-fopenmp")
+            # logic for Debug build: no optimizatrion and debug symbols
+            if self.spec.satisfies("+debug"):
+                targets.append("FLAGS_ARM=-O0 -g")
+                targets.append("CFLAGS_ARM=-O0 -g")
+            else:
+                targets.append("FLAGS_ARM=-O3")
+                targets.append("CFLAGS_ARM=-O3")
+
+
+        elif self.spec.satisfies("%xl"):
+            targets.append("COMPILER=XLF")
+
+        return targets
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        mkdirp(prefix.doc.tests)
+
+        install("./clover_leaf", prefix.bin)
+        install("./clover.in", prefix.bin)
+        install("./*.in", prefix.doc.tests)
+        if os.path.exists("InputDecks"):
+            install_tree("InputDecks", prefix.doc.tests)

--- a/repo/v1.0/spack_repo/isamrepo/packages/et/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/et/package.py
@@ -1,0 +1,99 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Et(CMakePackage):
+    """
+    eT is an open source program with coupled cluster, multiscale and multilevel methods.
+    """
+
+    homepage = "https://etprogram.org"
+    git = "https://gitlab.com/eT-program/eT"
+
+    license("GPL-3.0-only")
+
+    version("development", branch="development", submodules=True )
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    depends_on("mpi")
+    depends_on("python@3.7:")
+    depends_on("lapack")
+    depends_on("blas")
+    depends_on("libint@2:")
+    depends_on("cmake@3.22:", type="build")
+    
+    @property
+    def build_directory(self):
+        return os.path.join(self.prefix,"build")
+
+    @property
+    def root_cmakelists_dir(self) -> str:
+        """The relative path to the directory containing CMakeLists.txt
+
+        This path is relative to the root of the extracted tarball,
+        not to the ``build_directory``. Defaults to the current directory.
+        """
+        return self.prefix
+
+    def patch(self):
+        filter_file(
+            r"(default_path =.*.parent)",
+            r"\1.parent",
+            "dev_tools/autogenerate_files.py"
+        )
+
+    def cmake_args(self):
+        args = []
+        mathlibs = self.spec['blas'].libs + self.spec['lapack'].libs
+        args.extend(
+            [
+                f"-DENABLE_64BIT_INTEGERS=ON",
+                f"-DENABLE_OMP=ON",
+                f"-DENABLE_THREADED_MKL=ON",
+                f"-DENABLE_RUNTIME_CHECKS=OFF",
+                f"-DENABLE_FORCED_BATCHING=OFF",
+                f"-DENABLE_INITIALIZE_NAN=OFF",
+                f"-DENABLE_PCMSOLVER=OFF",
+                f"-DENABLE_PFUNIT=OFF",
+                f"-DINTEGRAL_LIBRARY=libint",
+                f"-DOEI_LIBRARY=libint",
+                f"-DERI_LIBRARY=libint",
+                f"-DLIBINT2_ROOT=" + self.spec["libint"].prefix,
+                f"-DENABLE_AUTO_BLAS=OFF",
+                f"-DENABLE_AUTO_LAPACK=OFF",
+                f"-DEXTRA_LINKER_FLAGS={mathlibs.ld_flags}",
+            ]
+        )
+
+        return args
+
+    def cmake(self, spec, prefix):
+        # Run generator
+        # Builds in-place.
+        install_tree(".", prefix)
+        python = which("python")
+        with working_dir(self.prefix):
+            python("./dev_tools/autogenerate_files.py")
+        options = self.std_cmake_args
+        options += self.cmake_args()
+        options.append(os.path.abspath(self.root_cmakelists_dir))
+        with working_dir(self.build_directory, create=True):
+            cmake(*options)
+
+    def install(self, spec, prefix):
+        pass
+
+    def setup_run_environment(self, env):
+        etdir = join_path(self.prefix, "build")
+        env.prepend_path("PATH", etdir)

--- a/repo/v1.0/spack_repo/isamrepo/packages/hopr/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/hopr/package.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import glob
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Hopr(CMakePackage):
+    """
+    HOPR is an open-source tool for the generation of three-dimensional unstructured high-order meshes.
+    """
+
+    homepage = "https://hopr.readthedocs.io"
+    git = "https://github.com/hopr-framework/hopr.git"
+
+    license("GPL-3.0-only")
+
+    version("master", commit="e54eddedc613f1cd32439b55a7e2f428ceb116ce", get_full_repo=True)
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    depends_on("mpi")
+    depends_on("hdf5@1.12.0+fortran")
+    depends_on("lapack")
+    # CGNS at 3.4.1 has CMake issues due to h5dump
+    # See: https://github.com/CGNS/CGNS/pull/215
+    #depends_on("cgns@3.4.1+fortran")
+    depends_on("cmake@3.17:", type="build")
+
+    def patch(self):
+        filter_file(
+                r"EXECUTE_PROCESS\(COMMAND git ls-remote --get-url OUTPUT_VARIABLE GIT_ORIGIN\)",
+                "EXECUTE_PROCESS(COMMAND git ls-remote --get-url WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_VARIABLE GIT_ORIGIN)",
+                "CMakeListsLib.txt")
+
+    def cmake_args(self):
+        args = []
+        args.extend(
+            [
+                "-DHDF5_DIR=" + self.spec["hdf5"].prefix,
+                "-DLIBS_BUILD_HDF5=OFF",
+                "-DLIBS_BUILD_CGNS=OFF",
+                "-DLIBS_USE_CGNS=OFF",
+                "-DCMAKE_EXE_LINKER_FLAGS=" + self.spec['lapack'].libs.ld_flags
+            ]
+        )
+        return args

--- a/repo/v1.0/spack_repo/isamrepo/packages/kalign2/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/kalign2/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
+
+from spack.package import *
+
+class Kalign2(AutotoolsPackage):
+    """A fast and accurate multiple sequence alignment algorithm"""
+
+    homepage = "https://msa.sbc.su.se"
+    version(
+        "2.04",
+        sha256="8cf20ac4e1807dc642e7ffba8f42a117313beccaee4f87c5555d53a2eeac4cbb",
+        url="http://msa.sbc.su.se/downloads/kalign/current.tar.gz",
+    )
+
+    def patch(self):
+        """Change hard-coded prefix path"""
+        filter_file("/usr/local/bin", self.prefix.bin, "Makefile.in")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("kalign", prefix.bin)

--- a/repo/v1.0/spack_repo/isamrepo/packages/libint/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/libint/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package_base import PackageBase # Or other base class
+
+from spack_repo.builtin.packages.libint.package import TUNE_VARIANTS, Libint as LibintBuiltin
+
+from spack.package import *
+
+class Libint(LibintBuiltin):
+    
+    variant(
+        "mytune",
+        default="none",
+        multi=False,
+        values=('et',),
+        description="Tune libint for use with the given package",
+    )
+
+    def configure_args(self):
+        config_args = super().configure_args() # Call parent method
+        tune_value = self.spec.variants["mytune"].value
+        if tune_value.startswith("et"):
+            config_args += [
+                "--enable-1body=1",
+                "--enable-eri=1",
+                "--enable-eri2=1",
+                "--enable-eri3=1",
+                "--with-max-am=6",
+                "--with-opt-am=4",
+            ]
+        return config_args
+
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/libtorch/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/libtorch/package.py
@@ -1,0 +1,66 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Libtorch(CMakePackage):
+    """
+    The core of pytorch does not depend on Python. A CMake-based
+    build system compiles the C++ source code into a shared object, 
+    libtorch.so.
+    """
+
+    homepage = "https://pytorch.org"
+    git = "https://github.com/pytorch/pytorch"
+
+    license("BSD-3-Clause")
+
+    version("1.13.1", tag="v1.13.1",
+            commit="49444c3e546bf240bed24a101e747422d1f8a0ee",
+            submodules=True)
+
+    variant("build_type", default="Release",
+            description="CMake build type",
+            values=("Debug", "Release"))
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    
+    depends_on("python@:3.11")
+    depends_on("py-pyyaml")
+    depends_on("py-typing-extensions")
+    depends_on("py-setuptools")
+    
+    patch(
+        "https://github.com/facebookincubator/gloo/commit/4a5e339b764261d20fc409071dc7a8b8989aa195.patch?full_index=1",
+        sha256="dc8b3a9bea4693f32d6850ea2ce6ce75e1778538bfba464b50efca92bac425e3",
+        working_dir="third_party/gloo",
+    )
+    patch(
+        "https://github.com/pytorch/pytorch/commit/9d99d8879cb8a7a5ec94b04e933305b8d24ad6ac.patch?full_index=1",
+        sha256="8c3a5b22d0dbda2ee45cfc2ae1da446fc20898e498003579490d4efe9241f9ee",
+    )
+    patch(
+        "https://github.com/pytorch/kineto/commit/2ceb0a8cc04f9182b190f9214d4c6459d2021602.patch?full_index=1",
+        sha256="de78bfd185c92b65a82a70183ff391a39bee700b4053711115c1a45ae87b1cac",
+        working_dir="third_party/kineto",
+    )
+    patch(
+        "https://github.com/pytorch/pytorch/commit/aaa3eb059a0294cc01c71f8e74abcebc33404e17.patch?full_index=1",
+        sha256="8dcbc5cd24b4c0e4a051e2161700b485c6c598b66347e7e90a263d9319c76374",
+    )
+
+    def cmake_args(self):
+        args = [
+            self.define("BUILD_SHARED_LIBS", "ON"),
+            self.define("PYTHON_EXECUTABLE", which("python3")),
+        ]
+
+        return args
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/mace_lammps/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/mace_lammps/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class MaceLammps(CMakePackage):
+    """
+    MACE provides fast and accurate machine learning interatomic 
+    potentials with higher order equivariant message passing with
+    interface to LAMMPS which stands for Large-scale Atomic/Molecular Massively
+    Parallel Simulator. 
+    """
+
+    homepage = "https://mace-docs.readthedocs.io"
+    git = "https://github.com/ACEsuit/lammps"
+
+    license("GPL-2.0-only")
+
+    version("develop", commit="f51963aada27c5df4a87a37faec5a4125d0f2e82")
+    
+    depends_on("cxx", type="build")
+
+    depends_on("mpi")
+    depends_on("py-torch")
+    
+    root_cmakelists_dir = "cmake"
+
+    def cmake_args(self):
+        args = [
+            self.define("CMAKE_CXX_STANDARD", 17),
+            self.define("CMAKE_CXX_STANDARD_REQUIRED", "ON"),
+            self.define("BUILD_MPI", "ON"),
+            self.define("BUILD_OMP", "ON"),
+            self.define("PKG_OPENMP", "ON"),
+            self.define("PKG_ML-MACE", "ON"),
+        ]
+
+        return args
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/minibude/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/minibude/package.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+class Minibude(CMakePackage):
+    """implementation of the core computation of the Bristol University 
+    Docking Engine (BUDE) in different HPC programming models"""
+
+    homepage = "https://github.com/UoB-HPC/miniBUDE"
+    git = "https://github.com/UoB-HPC/miniBUDE.git"
+
+    maintainers("green-br")
+
+    license("Apache-2.0", checked_by="green-br")
+
+    version("main",  branch="main")
+
+    variant(
+        "model", default="serial", description="Implementation to build",
+        values=("omp", "serial"), multi=False
+    )
+
+    depends_on('cxx', type='build')
+
+    def cmake_args(self):
+        args = ["--trace","-DRELEASE_FLAGS=-O3;-ffast-math"]
+        #args = []
+        if self.spec.variants["model"].value == "serial":
+            args.append("-DMODEL=serial")
+        elif self.spec.variants["model"].value == "omp":
+            args.append("-DMODEL=omp")
+
+        return args
+    
+    def install(self, spec, prefix):
+        with working_dir(self.build_directory):
+            make("install")
+
+        mkdirp(prefix.doc.tests)
+        # Copy some test data to install location. 
+        with working_dir(self.stage.source_path):
+            install_tree("data", prefix.doc.tests)
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/nccl/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/nccl/package.py
@@ -1,0 +1,103 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Nccl(MakefilePackage, CudaPackage):
+    """Optimized primitives for collective multi-GPU communication."""
+
+    homepage = "https://github.com/NVIDIA/nccl"
+    url = "https://github.com/NVIDIA/nccl/archive/v2.7.3-1.tar.gz"
+
+    maintainers("adamjstewart")
+    libraries = ["libnccl.so"]
+
+    version("2.27.5-1", sha256="e8a8972fc7f7517703510ef23608d41f6484db5331fca37827b4af3f66995344")
+    version("2.27.3-1", sha256="97cde99265d0b76004b96e258deea6365df18ff9a292b8588f648e59c3ce1f2e")
+    version("2.26.6-1", sha256="2a4f86198510e1f0764c116b33ff70e082240f87d158b2017d7f34c7c3768ac6")
+    version("2.26.2-1", sha256="74c6ab40c864d79c2139508e9419de5970cb406ec85f001d5f834d5f5c0c4f3b")
+    version("2.25.1-1", sha256="7b154ad1f8ccafa795ed6696507d402b1b4ccac944c5fceb7f4e29b19a39cc47")
+    version("2.24.3-1", sha256="3028730b41e952d8e0441a2a62cf06a2267ec5a875c511a28c7904acc3d10b2a")
+    version("2.23.4-1", sha256="6b946b70a9d2d01871842cbd15ec56488d358abe9a0f3767e372fddc3e241ba7")
+    version("2.22.3-1", sha256="45151629a9494460e73375281e8b0fe379141528879301899ece9b776faca024")
+    version("2.21.5-1", sha256="1923596984d85e310b5b6c52b2c72a1b93da57218f2bc5a5c7ac3d59297a3303")
+    version("2.20.3-1", sha256="19456bd63ca7d23a8319cbbdbaaf6c25949dd51161a9f8809f6b7453282983dd")
+    version("2.19.3-1", sha256="1c5474553afedb88e878c772f13d6f90b9226b3f2971dfa6f873adb9443100c2")
+    version("2.18.5-1", sha256="16ac98f3e926c024ce48e10ab220e19ce734adc48c423cfd55ad6f509bd1179f")
+    version("2.18.3-1", sha256="6477d83c9edbb34a0ebce6d751a1b32962bc6415d75d04972b676c6894ceaef9")
+    version("2.18.1-1", sha256="0e4ede5cf8df009bff5aeb3a9f194852c03299ae5664b5a425b43358e7a9eef2")
+    version("2.17.1-1", sha256="1311a6fd7cd44ad6d4523ba03065ce694605843fd30a5c0f77aa3d911abe706d")
+    version("2.16.2-1", sha256="7f7c738511a8876403fc574d13d48e7c250d934d755598d82e14bab12236fc64")
+    version("2.15.5-1", sha256="f4ac3c74d469c9cd718f82e1477759785db9b9f8cc9d9ecc103485805b8394a3")
+    version("2.14.3-1", sha256="0fffb6f91e029ea4d95efabd7bddc6eecf8bf136e4f46bf812bff7d8eee53c79")
+    version("2.13.4-1", sha256="d5f5243200d4e40683c56f04435bfd6defa379cb4f2b8c07b0f191df0f66c3d9")
+    version("2.12.12-1", sha256="49b4fbfeebf1f62f6ceb69e72504045d8d1b4e7609e3c2477906f3004c7e2d82")
+    version("2.12.10-1", sha256="7f53ed9f1af25bf5290e774d4fbe7a8fc71bcad34ab943602d36e4d0a8d30d16")
+    version("2.12.7-1", sha256="928d02e61637128f53320a89088c9c2e597fe9d25548dfaf06238bf5a87420fd")
+    version("2.11.4-1", sha256="db4e9a0277a64f9a31ea9b5eea22e63f10faaed36dded4587bbc8a0d8eceed10")
+    version("2.10.3-1", sha256="55de166eb7dcab9ecef2629cdb5fb0c5ebec4fae03589c469ebe5dcb5716b3c5")
+    version("2.9.9-1", sha256="01629a1bdadbadb2828e26023ba7685bbc07678468cb7df63cc96460f5337e08")
+    version("2.9.8-1", sha256="f6e5d9c10e6e54ee21f9707d2df684083d0cccf87bd5a4dbc795803da2bc9f5a")
+    version("2.9.6-1", sha256="c4b1f5a88f03c0ac8f1dcbe27723cd75cfe051754078d83629efaaed10ce8731")
+    version("2.8.4-1", sha256="a5c1b4da6e1608ee63baa87f6df424bba7a8b1cedad597a25d5b4cf8d56d0865")
+    version("2.8.3-1", sha256="3ae89ddb2956fff081e406a94ff54ae5e52359f5d645ce977c7eba09b3b782e6")
+    version("2.7.8-1", sha256="fa2bec307270f30fcf6280a85f24ea8801e0ce3b3027937c7325260a890b07e0")
+    version("2.7.6-1", sha256="60dd9b1743c2db6c05f60959edf98a4477f218115ef910d7ec2662f2fb5cf626")
+    version("2.7.5-1", sha256="26a8dec6fa0a776eb71205d618d58e26d372621719788a23b33db6fdce4426bf")
+    version("2.7.3-1", sha256="dc7b8794373306e323363314c3327796e416f745e8003490fc1407a22dd7acd6")
+    version("2.6.4-1", sha256="ed8c9dfd40e013003923ae006787b1a30d3cb363b47d2e4307eaa2624ebba2ba")
+    version("2.5.7-1", sha256="781a6bb2278566be4abbdf22b2fa19afc7306cff4b312c82bd782979b368014e")
+    version("2.5.6-2", sha256="8a30e0b4813a825592872fcbeeede22a659e2c399074dcce02960591dc81387d")
+    version("2.5.6-1", sha256="38a37d98be11f43232b988719226866b407f08b9666dcaf345796bd8f354ef54")
+    version("2.4.8-1", sha256="e2260da448ebbebe437f74768a346d28c74eabdb92e372a3dc6652a626318924")
+    version("2.4.6-1", sha256="ea4421061a7b9c454f2e088f68bfdbbcefab80ce81cafc70ee6c7742b1439591")
+    version("2.4.2-1", sha256="e3dd04b22eb541394bd818e5f78ac23a09cc549690d5d55d6fccc1a36155385a")
+    version("2.3.7-1", sha256="e6eff80d9d2db13c61f8452e1400ca2f098d2dfe42857cb23413ce081c5b9e9b")
+    version("2.3.5-5", sha256="bac9950b4d3980c25baa8e3e4541d2dfb4d21edf32ad3b89022d04920357142f")
+
+    variant("cuda", default=True, description="Build with CUDA")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
+    # Not required for all implementations (and only at runtime).
+    #depends_on("rdma-core")
+
+    # https://github.com/NVIDIA/nccl/issues/244
+    patch("so_reuseport.patch", when="@2.3.7-1:2.4.8-1")
+
+    conflicts("~cuda", msg="NCCL requires CUDA")
+    conflicts(
+        "cuda_arch=none",
+        msg="Must specify CUDA compute capabilities of your GPU, see "
+        "https://developer.nvidia.com/cuda-gpus",
+    )
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r"lib\S*\.so\.(\d+\.\d+\.\d+)", lib)
+        return match.group(1) if match else None
+
+    @property
+    def build_targets(self):
+        cuda_arch = self.spec.variants["cuda_arch"].value
+        cuda_gencode = " ".join(self.cuda_flags(cuda_arch))
+
+        return [
+            "CUDA_HOME={0}".format(self.spec["cuda"].prefix),
+            "NVCC_GENCODE={0}".format(cuda_gencode),
+        ]
+
+    @property
+    def install_targets(self):
+        if self.version >= Version("2.3.5-5"):
+            return ["PREFIX={0}".format(self.prefix), "src.install"]
+        else:
+            return ["PREFIX={0}".format(self.prefix), "install"]

--- a/repo/v1.0/spack_repo/isamrepo/packages/nccl/so_reuseport.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/nccl/so_reuseport.patch
@@ -1,0 +1,16 @@
+diff --git a/src/include/socket.h b/src/include/socket.h
+index 68ce235..b4f09b9 100644
+--- a/src/include/socket.h
++++ b/src/include/socket.h
+@@ -327,7 +327,11 @@ static ncclResult_t createListenSocket(int *fd, union socketAddress *localAddr)
+   if (socketToPort(&localAddr->sa)) {
+     // Port is forced by env. Make sure we get the port.
+     int opt = 1;
++#if defined(SO_REUSEPORT)
+     SYSCHECK(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt)), "setsockopt");
++#else
++    SYSCHECK(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)), "setsockopt");
++#endif
+   }
+ 
+   // localAddr port should be 0 (Any port)

--- a/repo/v1.0/spack_repo/isamrepo/packages/nccl_tests/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/nccl_tests/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package_base import PackageBase # Or other base class
+
+# Import the original Mpich class from the 'builtin' repository
+from spack_repo.builtin.packages.nccl_tests.package import NcclTests as BuiltinNcclTests
+
+from spack.package import *
+
+
+class NcclTests(BuiltinNcclTests):
+    depends_on("aws-ofi-nccl", type="run")
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/neutral/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/neutral/package.py
@@ -1,0 +1,85 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Neutral(MakefilePackage):
+    """
+    A Monte Carlo Neutron Transport Mini-App
+    """
+
+    homepage = "https://github.com/UoB-HPC/neutral"
+    git = "https://github.com/green-br/neutral.git"
+
+    maintainers("green-br")
+
+    version("master", commit="c50e50fcd903104bf9ad3ac7b84a27ba4428bef1", submodules=True)
+
+    depends_on("c", type="build")  # generated
+
+    depends_on("mpi", when="+mpi")
+
+    variant("openmp", default=True, description="Build with OpenMP support")
+    variant("mpi", default=True, description="Build with MPI support.")
+    
+    # Cloverleaf_ref Makefile contains some but not all required options for each compiler.
+    # This package.py inserts what is needed for Intel, AOCC, and LLVM compilers.
+    @property
+    def build_targets(self):
+
+        targets = []
+
+        targets.append("KERNELS=omp3")
+        targets.append("MPI=yes")
+        targets.append("ARCH_COMPILER_CC={0}".format(self.spec["mpi"].mpicc))
+
+        # Work around for bug in Makefiles for versions 1.3 and 1.1 (mis-defined as -openmp)
+        if self.spec.satisfies("%intel"):
+            targets.append("COMPILER=INTEL")
+
+        # Work around for missing AOCC compilers option in Makefiles for versions 1.3 and 1.1
+        elif self.spec.satisfies("%aocc"):
+            targets.append("COMPILER=AOCC")
+            targets.append("CFLAGS_AOCC=-fopenmp")
+
+        # Work around for missing CLANG entries in Makefiles for master branch (commit:0fdb917),
+        # and for versions 1.3 and 1.1
+        elif self.spec.satisfies("%clang"):
+            targets.append("COMPILER=CLANG")
+            targets.append("CFLAGS_CLANG=-fopenmp")
+
+        elif self.spec.satisfies("%gcc"):
+            targets.append("COMPILER=GNU")
+            targets.append("CFLAGS_GNU=-fopenmp")
+
+        elif self.spec.satisfies("%cce"):
+            targets.append("COMPILER=CRAY")
+            targets.append("CFLAGS_CRAY=-fopenmp")
+       
+        elif self.spec.satisfies("%nvhpc"):
+            targets.append("COMPILER=NVHPC")
+            targets.append("CFLAGS_NVHPC=-mp")
+        
+        elif self.spec.satisfies("%arm"):
+            targets.append("COMPILER=ARM")
+            targets.append("CFLAGS_ARM=-fopenmp")
+
+        elif self.spec.satisfies("%xl"):
+            targets.append("COMPILER=XL")
+            targets.append("CFLAGS_XL=-fopenmp")
+
+        return targets
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        mkdirp(prefix.doc.tests)
+
+        install("./neutral.omp3", prefix.bin)
+        install("./problems/*", prefix.doc.tests)

--- a/repo/v1.0/spack_repo/isamrepo/packages/openmm/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/openmm/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+# Import the original Mpich class from the 'builtin' repository
+from spack_repo.builtin.packages.openmm.package import Openmm as BuiltinOpenmm
+
+from spack.package import *
+
+class Openmm(BuiltinOpenmm):
+    version("8.1.2", sha256="afc888a4e46486d8d68dac4d403e2b0b28f51b95e52e821e34c38e8b428e040e")
+    
+    def patch(self):
+        super().patch()  # Call parent method
+        install_string = f'set(PYTHON_SETUP_COMMAND "install")'
+
+        filter_file(
+            r"set\(PYTHON_SETUP_COMMAND \"install.*",
+            install_string,
+            "wrappers/python/CMakeLists.txt",
+        )
+        filter_file(
+            r"HWCAP_NEON",
+            "HWCAP_ASIMD",
+            "openmmapi/include/openmm/internal/vectorize_neon.h",
+        )
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/orca/mpirun_srun.sh
+++ b/repo/v1.0/spack_repo/isamrepo/packages/orca/mpirun_srun.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Replacement wrapper for mpirun when only srun is available
+
+srun $(echo "${@}" | sed 's/-np/-n/')

--- a/repo/v1.0/spack_repo/isamrepo/packages/orca/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/orca/package.py
@@ -1,0 +1,85 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import platform
+
+from spack_repo.builtin.build_systems.generic import Package
+
+from spack.package import *
+
+_versions = {
+    "6.0.1": {
+        "Linux-aarch64": "0699cbccb6dbee66e14e69c4bb1300b35820b4222afdd7371e50aa23fe28be48",
+        "Linux-x86_64": "5e9b49588375e0ce5bc32767127cc725f5425917804042cdecdfd5c6b965ef61",
+    },
+}
+
+class Orca(Package):
+    """An ab initio, DFT and semiempirical SCF-MO package
+
+    Note: Orca is licensed software. You will need to create an account
+    on the Orca homepage and download Orca yourself. Spack will search
+    your current directory for the download file. Alternatively, add this
+    file to a mirror so that Spack can find it. For instructions on how to
+    set up a mirror, see https://spack.readthedocs.io/en/latest/mirrors.html"""
+
+    homepage = "https://cec.mpg.de"
+    maintainers("snehring")
+    manual_download = True
+
+    license("LGPL-2.1-or-later")
+    
+    for ver, packages in _versions.items():
+        key = "{0}-{1}".format(platform.system(), platform.machine())
+        sha_val = packages.get(key)
+        if sha_val:
+            version(ver, sha256=sha_val, deprecated=packages.get("deprecated", False))
+    
+    depends_on("libevent", type="run")
+    depends_on("libpciaccess", type="run")
+
+    # Map Orca version with the required OpenMPI version
+    # OpenMPI@4.1.1 has issues in pmix environments, hence 4.1.2 here
+    openmpi_versions = {
+        "6.0.1": "4.1.8",
+    }
+
+    for orca_version, openmpi_version in openmpi_versions.items():
+        depends_on(
+            "openmpi@{0}".format(openmpi_version), type="run", when="@{0}".format(orca_version)
+        )
+
+    def url_for_version(self, version):
+        openmpi_version = self.openmpi_versions[version.string].replace(".", "")
+        if openmpi_version == "412":
+            openmpi_version = "411"
+        ver_parts = version.string.split("-")
+        ver_underscored = ver_parts[-1].replace(".", "_")
+        features = ver_parts[:-1] + ["shared"]
+        feature_text = "_".join(features)
+        orca_arch = "linux_x86-64"
+        if platform.system() == "Linux" and platform.machine() == "aarch64":
+            orca_arch = "linux_arm64"
+        return f"file://{os.getcwd()}/orca_{ver_underscored}_{orca_arch}_{feature_text}_openmpi{openmpi_version}.tar.xz"
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+
+        install_tree(".", prefix.bin)
+
+        # Check "mpirun" usability when building against OpenMPI
+        # with Slurm scheduler and add a "mpirun" wrapper that
+        # calls "srun" if need be
+        if "^openmpi ~legacylaunchers schedulers=slurm" in self.spec:
+            mpirun_srun = join_path(os.path.dirname(__file__), "mpirun_srun.sh")
+            install(mpirun_srun, prefix.bin.mpirun)
+
+    def setup_run_environment(self, env):
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.bin)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["libevent"].prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["libpciaccess"].prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["openmpi"].prefix.lib)

--- a/repo/v1.0/spack_repo/isamrepo/packages/piclas/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/piclas/package.py
@@ -1,0 +1,82 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import glob
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class Piclas(CMakePackage):
+    """
+    PICLas is a three-dimensional simulation framework for Particle-in-Cell,
+    Direct Simulation Monte Carlo and other particle methods that can be
+    coupled for the simulation of collisional plasma flows.
+    """
+
+    homepage = "https://piclas.readthedocs.io"
+    git = "https://github.com/green-br/piclas.git"
+
+    license("GPL-3.0-only")
+
+    variant("eqnsysname", default="auto", description="Equation system to be solved", 
+        values=(
+            "auto",
+            "poisson",
+            "maxwell",
+        ),
+        multi=False
+    )
+    
+    variant("timediscmethod", default="auto", description="Time integration method", 
+        values=(
+            "auto",
+            "leapfrog",
+            "boris-leapfrog",
+            "higuera-cary",
+            "RK3",
+            "RK4",
+            "RK14",
+            "dsmc",
+            "fp-flow",
+            "bgk-flow",
+        ), 
+        multi=False
+    )
+
+    version("v3.5.0", commit="270572d6877088c5cf1a06b202aed04db2de058e" )
+    version("master", commit="623d8b8bc89a90399501259b25328588982096dc" )
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    depends_on("mpi")
+    depends_on("hdf5@1.14.0+fortran")
+    depends_on("petsc@3.19.3")
+    depends_on("cmake@3.17:", type="build")
+
+    def cmake_args(self):
+        args = []
+        args.extend(
+            [
+                "-DHDF5_DIR=" + self.spec["hdf5"].prefix,
+                "-DPETSC_DIR=" + self.spec["petsc"].prefix,
+                "-DPETSC_ARCH=.",
+            ]
+        )
+        if self.spec.satisfies("%gcc@10:"):
+            args.append(
+                self.define("CMAKE_Fortran_FLAGS", "-fallow-argument-mismatch")
+            )
+        if self.spec.variants["eqnsysname"].value != "auto":
+            args.append("-DPICLAS_EQNSYSNAME=" + self.spec.variants["eqnsysname"].value)
+
+        if self.spec.variants["timediscmethod"].value != "auto":
+            args.append("-DPICLAS_TIMEDISCMETHOD=" + self.spec.variants["timediscmethod"].value)
+
+        return args

--- a/repo/v1.0/spack_repo/isamrepo/packages/py_torch/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/py_torch/package.py
@@ -1,0 +1,27 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package_base import PackageBase # Or other base class
+
+# Import the original Mpich class from the 'builtin' repository
+from spack_repo.builtin.packages.py_torch.package import PyTorch as BuiltinPyTorch
+
+from spack.package import *
+
+class PyTorch(BuiltinPyTorch):
+    patch(
+        "https://github.com/pytorch/pytorch/commit/9d99d8879cb8a7a5ec94b04e933305b8d24ad6ac.patch?full_index=1",
+        sha256="8c3a5b22d0dbda2ee45cfc2ae1da446fc20898e498003579490d4efe9241f9ee",
+    )
+    patch(
+        "https://github.com/pytorch/kineto/commit/2ceb0a8cc04f9182b190f9214d4c6459d2021602.patch?full_index=1",
+        sha256="de78bfd185c92b65a82a70183ff391a39bee700b4053711115c1a45ae87b1cac",
+        working_dir="third_party/kineto",
+    )
+    patch(
+        "https://github.com/pytorch/pytorch/commit/aaa3eb059a0294cc01c71f8e74abcebc33404e17.patch?full_index=1",
+        sha256="8dcbc5cd24b4c0e4a051e2161700b485c6c598b66347e7e90a263d9319c76374",
+    )
+
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/relion/0002-Simple-patch-to-fix-intel-mkl-linking.patch
+++ b/repo/v1.0/spack_repo/isamrepo/packages/relion/0002-Simple-patch-to-fix-intel-mkl-linking.patch
@@ -1,0 +1,31 @@
+From 0448e229d5c38d00e8a4b9f7081a862e966f8c17 Mon Sep 17 00:00:00 2001
+From: Evan Bollig <ebbollig@amazon.com>
+Date: Tue, 9 Feb 2021 09:48:13 -0600
+Subject: [PATCH] Simple patch to fix intel mkl linking
+
+---
+ src/apps/CMakeLists.txt | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/apps/CMakeLists.txt b/src/apps/CMakeLists.txt
+index 9f23f797..b26d373d 100644
+--- a/src/apps/CMakeLists.txt
++++ b/src/apps/CMakeLists.txt
+@@ -212,6 +212,14 @@ foreach (_target ${RELION_TARGETS})
+ 		target_link_libraries(${_target} ${LIB} ${EXTRA_LIBS} ${MPI_LIBRARIES} ${CMAKE_DL_LIBS})
+ 	else()	
+ 		target_link_libraries(${_target} ${LIB} ${FFTW_LIBRARIES} ${EXTRA_LIBS} ${MPI_LIBRARIES} ${CMAKE_DL_LIBS})
++		# Intel MKL needs to be last in the list
++		if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
++			SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fopenmp -mkl -limf ")
++			#target_link_libraries(${_target} "fopenmp" "mkl" "imf")
++		else()
++			#SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lmkl_intel_ilp64 -lmkl_core -lmkl_sequential ")
++			target_link_libraries(${_target} "mkl_intel_ilp64" "mkl_core" "mkl_sequential")
++		endif()
+ 	endif(NOT MKLFFT)
+ 
+ 	if(CUDA_FOUND)
+-- 
+2.25.1
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/relion/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/relion/package.py
@@ -1,0 +1,159 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+
+from spack.package import *
+
+# Adds test tomg version and removes binutils dependency.
+class Relion(CMakePackage, CudaPackage):
+    """RELION (for REgularised LIkelihood OptimisatioN, pronounce rely-on) is a
+    stand-alone computer program that employs an empirical Bayesian approach to
+    refinement of (multiple) 3D reconstructions or 2D class averages in
+    electron cryo-microscopy (cryo-EM)."""
+
+    homepage = "http://www2.mrc-lmb.cam.ac.uk/relion"
+    git = "https://github.com/3dem/relion.git"
+    url = "https://github.com/3dem/relion/archive/4.0.0.zip"
+    maintainers("dacolombo")
+
+    license("GPL-2.0-only")
+
+    version("4.0.1", sha256="7e0d56fd4068c99f943dc309ae533131d33870392b53a7c7aae7f65774f667be")
+    version("4.0.0", sha256="0987e684e9d2dfd630f1ad26a6847493fe9fcd829ec251d8bc471d11701d51dd")
+
+    # 3.1.4 latest release in 3.1 branch
+    version("3.1.4", sha256="3bf3449bd2d71dc85d2cdbd342e772f5faf793d8fb3cda6414547cf34c98f34c")
+    version("3.1.3", sha256="e67277200b54d1814045cfe02c678a58d88eb8f988091573453c8568bfde90fc")
+    version("3.1.2", sha256="dcdf6f214f79a03d29f0fed2de58054efa35a9d8401543bdc52bfb177987931f")
+    version("3.1.1", sha256="63e9b77e1ba9ec239375020ad6ff631424d1a5803cba5c608c09fd44d20b1618")
+    version("3.1.0", sha256="8a7e751fa6ebcdf9f36046499b3d88e170c4da86d5ff9ad1914b5f3d178867a8")
+
+    # 3.0.8 latest release in 3.0 branch
+    version("3.0.8", sha256="18cdd58e3a612d32413eb37e473fe8fbf06262d2ed72e42da20356f459260973")
+    version("3.0.7", sha256="a6d37248fc4d0bfc18f4badb7986dc1b6d6849baa2128b0b4dade13cb6991a99")
+
+    # relion master contains development code
+    # contains 3.0 branch code
+    version("master", branch="master")
+    
+    version("tomg", branch="cudatoolkit_update", git="https://github.com/green-br/relion.git")
+
+    variant("gui", default=True, description="build the gui")
+    variant("cuda", default=True, description="enable compute on gpu")
+    variant("double", default=True, description="double precision (cpu) code")
+    variant("double-gpu", default=False, description="double precision gpu")
+
+    # if built with purpose=cluster then relion will link to gpfs libraries
+    # if that's not desirable then use purpose=desktop
+    variant(
+        "purpose",
+        default="cluster",
+        values=("cluster", "desktop"),
+        description="build relion for use in cluster or desktop",
+    )
+
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="The build type to build",
+        values=("Debug", "Release", "RelWithDebInfo", "Profiling", "Benchmarking"),
+    )
+
+    # these new values were added in relion 3
+    # do not seem to cause problems with < 3
+    variant("mklfft", default=True, description="Use MKL rather than FFTW for FFT")
+    variant(
+        "allow_ctf_in_sagd",
+        default=True,
+        description=(
+            "Allow CTF-modulation in SAGD, " "as specified in Claim 1 of patent US10,282,513B2"
+        ),
+    )
+    variant("altcpu", default=False, description="Use CPU acceleration", when="~cuda")
+
+    variant(
+        "external_motioncor2",
+        default=False,
+        description="Have external motioncor2 available in addition to " "Relion builtin",
+    )
+
+    depends_on("mpi")
+    depends_on("cmake@3:", type="build")
+    #depends_on("binutils@2.32:", type="build")
+    depends_on("fftw precision=float,double", when="~mklfft")
+
+    # use the +xft variant so the interface is not so horrible looking
+    depends_on("fltk+xft", when="+gui")
+
+    depends_on("libtiff")
+    depends_on("libpng", when="@4:")
+
+    depends_on("cuda", when="+cuda")
+    depends_on("cuda@9:", when="@3: +cuda")
+    depends_on("tbb", when="+altcpu")
+    depends_on("mkl", when="+mklfft")
+    depends_on("ctffind", type="run")
+    depends_on("motioncor2", type="run", when="+external_motioncor2")
+
+    # TODO: more externals to add
+    # Spack packages needed
+    # - Gctf
+    # - ResMap
+    patch("0002-Simple-patch-to-fix-intel-mkl-linking.patch", when="@:3.1.1 os=ubuntu18.04")
+    patch(
+        "https://github.com/3dem/relion/commit/2daa7447c1c871be062cce99109b6041955ec5e9.patch?full_index=1",
+        sha256="4995b0d4bc24a1ec99042a4b73e9db84918eb6f622dacb308b718146bfb6a5ea",
+        when="@4.0.0",
+    )
+
+    def cmake_args(self):
+        args = [
+            "-DCMAKE_C_FLAGS=-g",
+            "-DCMAKE_CXX_FLAGS=-g",
+            "-DGUI=%s" % ("+gui" in self.spec),
+            "-DDoublePrec_CPU=%s" % ("+double" in self.spec),
+            "-DDoublePrec_GPU=%s" % ("+double-gpu" in self.spec),
+            "-DALLOW_CTF_IN_SAGD=%s" % ("+allow_ctf_in_sagd" in self.spec),
+            "-DMKLFFT=%s" % ("+mklfft" in self.spec),
+            "-DALTCPU=%s" % ("+altcpu" in self.spec),
+        ]
+
+        if "+cuda" in self.spec:
+            carch = self.spec.variants["cuda_arch"].value[0]
+
+            # relion+cuda requires selecting cuda_arch
+            if carch == "none":
+                raise ValueError("Must select a value for cuda_arch")
+            else:
+                args += ["-DCUDA=ON", "-DCudaTexture=ON", "-DCUDA_ARCH=%s" % (carch)]
+
+        return args
+
+    def patch(self):
+        # Remove flags not recognized by the NVIDIA compilers
+        if self.spec.satisfies("%nvhpc"):
+            filter_file("-std=c99", "-c99", "src/apps/CMakeLists.txt")
+
+        # set up some defaults
+        filter_file(
+            r"(#define DEFAULTQSUBLOCATION).*",
+            r'\1 "{0}"'.format(join_path(self.spec.prefix.bin, "relion_qsub.csh")),
+            join_path("src", "pipeline_jobs.h"),
+        )
+        filter_file(
+            r"(#define DEFAULTCTFFINDLOCATION).*",
+            r'\1 "{0}"'.format(join_path(self.spec["ctffind"].prefix.bin, "ctffind")),
+            join_path("src", "pipeline_jobs.h"),
+        )
+
+
+        if "+external_motioncor2" in self.spec:
+            filter_file(
+                r"(#define DEFAULTMOTIONCOR2LOCATION).*",
+                r'\1 "{0}"'.format(join_path(self.spec["motioncor2"].prefix.bin, "MotionCor2")),
+                join_path("src", "pipeline_jobs.h"),
+            )

--- a/repo/v1.0/spack_repo/isamrepo/packages/snap/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/snap/package.py
@@ -1,0 +1,62 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+# Corrects OpenMP flag and resets FFLAGS.
+class Snap(MakefilePackage):
+    """SNAP serves as a proxy application to model
+    the performance of a modern discrete ordinates
+    neutral particle transport application.
+    SNAP may be considered an update to Sweep3D,
+    intended for hybrid computing architectures.
+    It is modeled off the Los Alamos National Laboratory code PARTISN."""
+
+    homepage = "https://github.com/lanl/SNAP"
+    git = "https://github.com/lanl/SNAP.git"
+
+    tags = ["proxy-app"]
+
+    license("Unlicense")
+
+    version("main")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    variant("openmp", default=False, description="Build with OpenMP support")
+    variant("opt", default=True, description="Build with debugging")
+    variant("mpi", default=True, description="Build with MPI support")
+
+    depends_on("mpi", when="+mpi")
+
+    build_directory = "src"
+
+    def edit(self, spec, prefix):
+        with working_dir(self.build_directory):
+            makefile = FileFilter("Makefile")
+            if "~opt" in spec:
+                makefile.filter("OPT = yes", "OPT = no")
+            if "~mpi" in spec:
+                makefile.filter("MPI = yes", "MPI = no")
+            if "~openmp" in spec:
+                makefile.filter("OPENMP = yes", "OPENMP = no")
+            
+            makefile.filter("OMPFLAG = -fopenmp", f"OMPFLAG = {self.compiler.openmp_flag}")
+            if self.spec.satisfies("%gcc@10:"):
+                makefile.filter("FFLAGS =.*", "FFLAGS = $(OMPFLAG) -fallow-argument-mismatch")
+            else:
+                makefile.filter("FFLAGS =.*", "FFLAGS = $(OMPFLAG)")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("src/gsnap", prefix.bin)
+        install_tree("qasnap", prefix.qasnap)
+        install("README.md", prefix)
+

--- a/repo/v1.0/spack_repo/isamrepo/packages/swiftsim/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/swiftsim/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package_base import PackageBase # Or other base class
+
+# Import the original Mpich class from the 'builtin' repository
+from spack_repo.builtin.packages.swiftsim.package import Swiftsim as BuiltinSwiftsim
+
+from spack.package import *
+
+class Swiftsim(BuiltinSwiftsim):
+    version("master", branch="master")
+    depends_on("fftw-api@3.3:")
+
+    def configure_args(self):
+        return [
+            "--enable-mpi" if "+mpi" in self.spec else "--disable-mpi",
+            "--with-metis={0}".format(self.spec["metis"].prefix),
+            "--with-fftw={0}".format(self.spec["fftw-api"].prefix),
+            "--disable-dependency-tracking",
+            "--enable-optimization",
+            "--enable-compiler-warnings=yes",
+            "--disable-vec",
+        ]

--- a/repo/v1.0/spack_repo/isamrepo/packages/tealeaf/package.py
+++ b/repo/v1.0/spack_repo/isamrepo/packages/tealeaf/package.py
@@ -1,0 +1,93 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import glob
+
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Tealeaf(MakefilePackage):
+    """Proxy Application. TeaLeaf is a mini-app that solves
+    the linear heat conduction equation on a spatially decomposed
+    regularly grid using a 5 point stencil with implicit solvers.
+    """
+
+    homepage = "https://uk-mac.github.io/TeaLeaf/"
+    url = "https://downloads.mantevo.org/releaseTarballs/miniapps/TeaLeaf/TeaLeaf-1.0.tar.gz"
+    git = "https://github.com/UK-MAC/TeaLeaf.git"
+
+    tags = ["proxy-app"]
+
+    license("LGPL-3.0-only")
+
+    version("1.0", sha256="e11799d1a3fbe76041333ba98858043b225c5d65221df8c600479bc55e7197ce")
+    version("master", branch="master", submodules=True)
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    depends_on("mpi")
+
+    def edit(self, spec, prefix):
+        filter_file("-march=native", "", join_path("TeaLeaf_ref", "Makefile"))
+
+    @property
+    def build_targets(self):
+        targets = [
+            "--directory=TeaLeaf_ref",
+            "MPI_COMPILER={0}".format(self.spec["mpi"].mpifc),
+            "C_MPI_COMPILER={0}".format(self.spec["mpi"].mpicc),
+            "CFLAGS_GNU=-O3 -funroll-loops",
+            "OMP_CRAY=-fopenmp",
+            "FLAGS_CRAY=-O3 -e Z",
+            "CFLAGS_CRAY=-O3",
+            "OMP_ARM=-fopenmp",
+            "FLAGS_ARM=-O3 -cpp",
+            "CFLAGS_ARM=-O3",
+            "OMP_NVHPC=-fopenmp",
+            "FLAGS_NVHPC=-O3 -cpp",
+            "CFLAGS_NVHPC=-O3",
+        ]
+        if self.spec.satisfies("%gcc@10:"):
+            targets.append("FLAGS_GNU=-O3 -fallow-argument-mismatch -funroll-loops -cpp -ffree-line-length-none")
+        else:
+            targets.append("FLAGS_GNU=-O3 -funroll-loops -cpp -ffree-line-length-none")
+
+        if "%gcc" in self.spec:
+            targets.append("COMPILER=GNU")
+        elif "%cce" in self.spec:
+            targets.append("COMPILER=CRAY")
+        elif "%intel" in self.spec:
+            targets.append("COMPILER=INTEL")
+        elif "%pgi" in self.spec:
+            targets.append("COMPILER=PGI")
+        elif "%xl" in self.spec:
+            targets.append("COMPILER=XL")
+        elif "%arm" in self.spec:
+            targets.append("COMPILER=ARM")
+        elif "%nvhpc" in self.spec:
+            targets.append("COMPILER=NVHPC")
+
+
+        return targets
+
+    def install(self, spec, prefix):
+        # Manual Installation
+        mkdirp(prefix.bin)
+        mkdirp(prefix.doc.tests)
+
+        install("README.md", prefix.doc)
+        install("TeaLeaf_ref/tea_leaf", prefix.bin)
+        install("TeaLeaf_ref/tea.in", prefix.bin)
+
+        for f in glob.glob("TeaLeaf_ref/*.in"):
+            install(f, prefix.doc.tests)
+        for f in glob.glob("TeaLeaf_ref/Benchmarks/*.in"):
+            install(f, prefix.doc.tests)
+       

--- a/repo/v1.0/spack_repo/isamrepo/repo.yaml
+++ b/repo/v1.0/spack_repo/isamrepo/repo.yaml
@@ -1,0 +1,3 @@
+repo:
+  namespace: 'isamrepo'
+  api: v2.0


### PR DESCRIPTION
The new version of Spack 1.0 introduces many changes to packages and configuration for compilers.  Created tests for packages in apps directories.  Package changes can be upstreamed now [spack-packages](spack/spack-packages) is available.

Will require documentation change especially regarding migration where v0.23 runs alongside v1.0. 