### PR TITLE
openmpi - enable slurm option as scheduler

### DIFF
--- a/config/3/v1.0/packages.yaml
+++ b/config/3/v1.0/packages.yaml
@@ -93,7 +93,7 @@ packages:
   mpich:
     variants: +fortran~hydra pmi=cray device=ch4 netmod=ofi
   openmpi:
-    variants: fabrics=ofi
+    variants: fabrics=ofi schedulers=slurm
   cray-fftw:
     buildable: false
     version: [3.3.10.8]
@@ -169,6 +169,10 @@ packages:
     - spec: python@3.11.7
       prefix: /opt/cray/pe/python/3.11.7
       modules: [cray-python/3.11.7]
+  slurm:
+    externals:
+    - spec: slurm@23-02-7
+      prefix: /usr
   autoconf:
     externals:
     - prefix: /usr

--- a/config/3/v1.1/packages.yaml
+++ b/config/3/v1.1/packages.yaml
@@ -93,7 +93,7 @@ packages:
   mpich:
     variants: +fortran~hydra pmi=cray device=ch4 netmod=ofi
   openmpi:
-    variants: fabrics=ofi
+    variants: fabrics=ofi schedulers=slurm
   cray-fftw:
     buildable: false
     version: [3.3.10.8]
@@ -157,6 +157,10 @@ packages:
     - spec: python@3.11.7
       prefix: /opt/cray/pe/python/3.11.7
       modules: [cray-python/3.11.7]
+  slurm:
+    externals:
+    - spec: slurm@23-02-07
+      prefix: /usr
   autoconf:
     externals:
     - prefix: /usr

--- a/config/aip1/v1.1/packages.yaml
+++ b/config/aip1/v1.1/packages.yaml
@@ -85,7 +85,7 @@ packages:
     require:
     - "%gcc"
   openmpi:
-    variants: +cuda fabrics=ofi cuda_arch=90
+    variants: +cuda fabrics=ofi cuda_arch=90 schedulers=slurm
   mpich:
     variants: +cuda+fortran~hydra pmi=cray device=ch4 netmod=ofi cuda_arch=90
   cray-libsci:

--- a/config/aip2/v1.1/packages.yaml
+++ b/config/aip2/v1.1/packages.yaml
@@ -84,7 +84,7 @@ packages:
     require:
     - "%gcc"
   openmpi:
-    variants: +cuda fabrics=ofi cuda_arch=90
+    variants: +cuda fabrics=ofi cuda_arch=90 schedulers=slurm
   mpich:
     variants: +cuda+fortran~hydra pmi=cray device=ch4 netmod=ofi cuda_arch=90
   cray-libsci:

--- a/config/macs3/v1.1/packages.yaml
+++ b/config/macs3/v1.1/packages.yaml
@@ -72,7 +72,7 @@ packages:
     require:
     - "^charmpp@8.0.0 backend=ofi pmi=cray-pmi"
   openmpi:
-    variants: fabrics=ofi
+    variants: fabrics=ofi schedulers=slurm
   cray-libsci:
     buildable: false
     version: [24.03.0]
@@ -135,6 +135,10 @@ packages:
     - spec: python@3.11.7
       prefix: /opt/cray/pe/python/3.11.7
       modules: [cray-python/3.11.7]
+  slurm:
+    externals:
+    - spec: slurm@23-02-7
+      prefix: /usr
   autoconf:
     externals:
     - prefix: /usr


### PR DESCRIPTION
#50 explains why enabling slurm support in openmpi is beneficial.